### PR TITLE
fix(executor): multi-line result strings were re-indented, breaking pi.edit matches

### DIFF
--- a/src/ui/structured.ts
+++ b/src/ui/structured.ts
@@ -21,6 +21,58 @@ export interface FormattedFabricValue {
   language?: "yaml" | "json";
 }
 
+interface HoistedSection {
+  path: string;
+  text: string;
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+// YAML literal block scalars must indent their content, so every multi-line
+// string serialized inside a structure is displayed with extra leading
+// whitespace on each line. Agents transcribe that corrupted indentation into
+// exact-match consumers (pi.edit oldText) and the match fails. Hoist
+// multi-line strings out of the YAML skeleton into raw sections so the
+// model-bound text preserves the original bytes.
+const hoistMultilineStrings = (
+  value: unknown,
+  path: string,
+  sections: HoistedSection[],
+  seen: Set<unknown>,
+): unknown => {
+  if (typeof value === "string") {
+    if (!value.includes("\n")) return value;
+    sections.push({ path, text: value });
+    return `<multi-line string, see section: ${path}>`;
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return "[circular reference]";
+    seen.add(value);
+    const skeleton = value.map((item, index) =>
+      hoistMultilineStrings(item, `${path}[${index}]`, sections, seen),
+    );
+    seen.delete(value);
+    return skeleton;
+  }
+  if (isPlainObject(value)) {
+    if (seen.has(value)) return "[circular reference]";
+    seen.add(value);
+    const skeleton: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      skeleton[key] = hoistMultilineStrings(
+        item,
+        path ? `${path}.${key}` : key,
+        sections,
+        seen,
+      );
+    }
+    seen.delete(value);
+    return skeleton;
+  }
+  return value;
+};
+
 export const formatFabricValue = (
   value: unknown,
   format: FabricResultFormat,
@@ -32,8 +84,20 @@ export const formatFabricValue = (
   }
   if (typeof value === "string") return { text: value };
   if (format === "auto" || format === "yaml") {
-    const yaml = formatJsonAsYaml(value);
-    if (yaml !== undefined) return { text: yaml, language: "yaml" };
+    const sections: HoistedSection[] = [];
+    const skeleton = hoistMultilineStrings(value, "", sections, new Set());
+    const yaml = formatJsonAsYaml(skeleton);
+    if (yaml !== undefined) {
+      if (sections.length === 0) return { text: yaml, language: "yaml" };
+      const raw = sections
+        .map(
+          (section) =>
+            `--- ${section.path} (${section.text.length} chars) ---\n${section.text}`,
+        )
+        .join("\n\n");
+      // No language tag: the skeleton is YAML but the raw sections are not.
+      return { text: `${yaml}\n\n${raw}` };
+    }
   }
   try {
     return {

--- a/tests/structured.test.ts
+++ b/tests/structured.test.ts
@@ -26,3 +26,42 @@ describe("formatFabricValue", () => {
     expect(formatFabricValue("already textual", "auto")).toEqual({ text: "already textual" });
   });
 });
+
+describe("multi-line string fidelity", () => {
+  // A multi-line string nested in a returned object must reach the model with
+  // its exact bytes. YAML literal block scalars indent every content line, so
+  // text transcribed from the display (e.g. into pi.edit oldText) does not
+  // match the file on disk.
+  const file = "function x() {\n    stopLoader();\n        deep();\n}";
+
+  it("hoists multi-line strings so content keeps its exact bytes", () => {
+    const formatted = formatFabricValue({ content: file }, "auto");
+    // content appears verbatim: 4-space and 8-space indents intact
+    expect(formatted.text).toContain("\n    stopLoader();\n");
+    expect(formatted.text).toContain("\n        deep();\n");
+    // never as a re-indented YAML block scalar
+    expect(formatted.text).not.toContain("      stopLoader();");
+    expect(formatted.text).not.toMatch(/\|\d?-/);
+  });
+
+  it("labels hoisted sections with their value path", () => {
+    const formatted = formatFabricValue(
+      { results: ["one\ntwo", { note: "a\nb" }] },
+      "auto",
+    );
+    expect(formatted.text).toContain("results[0]");
+    expect(formatted.text).toContain("results[1].note");
+    expect(formatted.text).toContain("one\ntwo");
+    expect(formatted.text).toContain("a\nb");
+  });
+
+  it("keeps single-line strings inline in the YAML skeleton", () => {
+    const formatted = formatFabricValue({ a: "x", b: 1 }, "auto");
+    expect(formatted).toEqual({ text: "a: x\nb: 1", language: "yaml" });
+  });
+
+  it("drops the yaml language tag when raw sections are appended", () => {
+    const formatted = formatFabricValue({ content: file }, "auto");
+    expect(formatted.language).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

`fabric_exec` programs batch tool calls and return one object. When that object contains multi-line strings, `formatFabricValue` serializes the return value with `yaml.stringify`. Multi-line strings become YAML literal block scalars (`|-`). YAML syntax indents block content, so every line of the string reaches the model with extra leading whitespace: two added spaces per nesting level.

```ts
// what the program returns
return { file: await pi.read("src/example.ts") };

// what the model sees
file: |-
  function x() {
      stopLoader();   // 4 real spaces, displayed as 6
          deep();     // 8 real spaces, displayed as 10
  }
```

The agent transcribes the displayed text into an exact-match consumer like `pi.edit` `oldText`. The edit fails with "Could not find the exact text", because the file on disk never had that indentation. The disk bytes are fine, and the read/edit tools are byte-faithful. So the failure looks like an edit-tool bug, but the corruption lives in the result renderer.

## Fix

Hoist multi-line strings out of the YAML skeleton into raw sections labeled by value path. The skeleton keeps a short marker per hoisted value. The sections carry the exact bytes:

```ts
return { file: await pi.read("src/example.ts") };

// what the model sees now
file: "<multi-line string, see section: file>"

--- file (50 chars) ---
function x() {
    stopLoader();   // exactly 4 spaces
        deep();     // exactly 8 spaces
}
```

Behavior notes:

- Single-line strings stay inline in the skeleton. Objects without multi-line strings render exactly as before.
- The walk hoists nested values and labels them by path (`results[0]`, `results[1].note`), so batched `Promise.all` returns work.
- The fix drops the `language: "yaml"` tag once it appends raw sections, since the output is no longer pure YAML. The tag only drove TUI syntax highlighting.
- This change leaves `formatJsonAsYaml` untouched. The dashboard keeps its human-facing YAML rendering.
- Circular references render as `[circular reference]` instead of crashing.

## Changes

- `src/ui/structured.ts`: add `hoistMultilineStrings` (recursive, cycle-safe walk); the auto/yaml path in `formatFabricValue` appends raw sections and omits `language` when the walk hoists a value
- `tests/structured.test.ts`: 4 regression tests: byte fidelity of indentation, path labels for nested and array values, single-line strings stay inline, language tag dropped with sections

The new tests fail on the old code for the right reason: the assertion that the text contains a newline plus exactly four spaces plus `stopLoader();` encodes the fix. The original failing pattern (batched parallel reads) now renders byte-faithful against the built `dist/` output.

Full suite: 848 passed, 0 failed. Typecheck and build clean.
