### PR TITLE
pi-tools: deduplicate truncated Bash results

### DIFF
--- a/src/providers/pi-tools-provider.ts
+++ b/src/providers/pi-tools-provider.ts
@@ -77,6 +77,16 @@ const normalizeResult = (
     return text;
   }
   let details = result.details;
+  if (name === "bash" && details && typeof details === "object" && !Array.isArray(details)) {
+    const detailRecord = details as Record<string, unknown>;
+    const truncation = detailRecord.truncation;
+    if (truncation && typeof truncation === "object" && !Array.isArray(truncation)) {
+      const { content, ...truncationMetadata } = truncation as Record<string, unknown>;
+      if (typeof content === "string" && text.includes(content)) {
+        details = { ...detailRecord, truncation: truncationMetadata };
+      }
+    }
+  }
   if (name === "write" && details && typeof details === "object" && !Array.isArray(details)) {
     const { codePreviewBeforeWrite: _before, ...publicDetails } = details as Record<string, unknown>;
     details = Object.keys(publicDetails).length > 0 ? publicDetails : undefined;

--- a/tests/pi-tools-provider.test.ts
+++ b/tests/pi-tools-provider.test.ts
@@ -107,6 +107,43 @@ describe("PiToolsProvider lifecycle", () => {
     expect((result as string).length).toBeGreaterThan(0);
   });
 
+  it("returns truncated Bash output once while preserving recovery metadata", async () => {
+    const registry = new ActionRegistry();
+    registry.register(new PiToolsProvider(process.cwd(), undefined, undefined));
+    const result = await registry.invoke(
+      "pi.bash",
+      {
+        command:
+          `node -e 'for (let i = 0; i < 5000; i++) console.log(i, "x".repeat(100))'`,
+      },
+      { ...baseContext, maxResultChars: 2_000_000 },
+    );
+    const bashResult = result as {
+      ok: boolean;
+      output: string;
+      details: {
+        fullOutputPath?: string;
+        truncation?: Record<string, unknown>;
+      };
+    };
+
+    try {
+      expect(bashResult).toMatchObject({
+        ok: true,
+        output: expect.any(String),
+        details: {
+          fullOutputPath: expect.any(String),
+          truncation: { truncated: true },
+        },
+      });
+      expect("content" in (bashResult.details.truncation ?? {})).toBe(false);
+    } finally {
+      if (bashResult.details.fullOutputPath) {
+        fs.rmSync(bashResult.details.fullOutputPath, { force: true });
+      }
+    }
+  });
+
   it("captures pre-write content out of band without changing the sandbox result", async () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fabric-write-preview-"));
     const before = `const value = 1;


### PR DESCRIPTION
Keep the retained tail in output while preserving truncation metadata and fullOutputPath for recovery.