### PR TITLE
fix(agents): preserve oversized event evidence

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1057,6 +1057,23 @@ const main = async (): Promise<void> => {
   const steerTimer = options.steerFile ? setInterval(pollSteer, 200) : undefined;
   steerTimer?.unref?.();
 
+  const failOversizedEvent = (line: string): void => {
+    const prefix = line.slice(0, MAX_EVENT_LINE_CHARS);
+    let artifactPath: string | undefined;
+    try {
+      artifactPath = path.join(path.dirname(options.logFile), "oversized-event-prefix.txt");
+      fs.writeFileSync(artifactPath, prefix, { encoding: "utf8", mode: 0o600 });
+    } catch {
+      artifactPath = undefined;
+    }
+    terminalStatus = "failed";
+    terminalError = artifactPath
+      ? `Agent emitted an oversized event line; first ${prefix.length} characters saved to: ${artifactPath}`
+      : "Agent emitted an oversized event line";
+    outputBuffer = "";
+    terminateChild(child, "SIGTERM");
+  };
+
   child.stdout?.on("data", (chunk: Buffer) => {
     const decoded = outputDecoder.write(chunk);
     if (options.runner === "veda") {
@@ -1068,18 +1085,12 @@ const main = async (): Promise<void> => {
       const newline = outputBuffer.indexOf("\n");
       if (newline < 0) {
         if (outputBuffer.length > MAX_EVENT_LINE_CHARS) {
-          terminalStatus = "failed";
-          terminalError = "Agent emitted an oversized event line";
-          outputBuffer = "";
-          terminateChild(child, "SIGTERM");
+          failOversizedEvent(outputBuffer);
         }
         break;
       }
       if (newline > MAX_EVENT_LINE_CHARS) {
-        terminalStatus = "failed";
-        terminalError = "Agent emitted an oversized event line";
-        outputBuffer = "";
-        terminateChild(child, "SIGTERM");
+        failOversizedEvent(outputBuffer.slice(0, newline));
         return;
       }
       const line = outputBuffer.slice(0, newline).replace(/\r$/, "");

--- a/tests/fixtures/fake-pi.mjs
+++ b/tests/fixtures/fake-pi.mjs
@@ -114,6 +114,14 @@ switch (behavior) {
     }, 10);
     break;
   }
+  case "oversized-event": {
+    const event = {
+      type: "message_end",
+      message: { role: "assistant", content: "x".repeat(4 * 1024 * 1024 + 1_024) },
+    };
+    process.stdout.write(`${JSON.stringify(event)}\n`, () => process.exit(0));
+    break;
+  }
   case "stderr-framing":
     process.stderr.write(
       JSON.stringify({ type: "message_end", message: { role: "assistant", content: "spoofed" } }),

--- a/tests/worker-e2e.test.ts
+++ b/tests/worker-e2e.test.ts
@@ -134,6 +134,24 @@ describe.skipIf(!hasWorker)("AgentManager real worker e2e", () => {
     }
   }, 30_000);
 
+  it("preserves a bounded prefix when an agent event exceeds the line limit", async () => {
+    process.env.FAKE_PI_BEHAVIOR = "oversized-event";
+    const result = await run("do it", 10_000);
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("Agent emitted an oversized event line");
+    const artifactPath = result.error?.match(/saved to: (.+)$/)?.[1];
+    expect(artifactPath).toBeDefined();
+    expect(path.dirname(artifactPath!)).toBe(path.dirname(result.logFile!));
+
+    const prefix = fs.readFileSync(artifactPath!, "utf8");
+    expect(prefix).toHaveLength(4 * 1024 * 1024);
+    expect(prefix).toMatch(/^\{"type":"message_end","message":\{"role":"assistant","content":"x+/);
+    if (process.platform !== "win32") {
+      expect(fs.statSync(artifactPath!).mode & 0o777).toBe(0o600);
+    }
+  }, 30_000);
+
   describe("agent session usage export", () => {
     const exportRoots: string[] = [];
     let savedExportEnv: string | undefined;


### PR DESCRIPTION
### Summary

- save the first 4 MiB of an oversized agent JSONL event beside the existing run log before terminating the child
- include the owner-only diagnostic path and captured character count in the existing failure message
- share one failure path across unterminated and completed oversized lines

### Scope

- keep `MAX_EVENT_LINE_CHARS`, failed run status, and immediate child termination unchanged
- keep the diagnostic bounded and mode `0600`
- use the existing run-directory retention lifecycle
- do not parse, recover, or continue processing the oversized event

### Validation

- `PI_CODING_AGENT_DIR=<test-owned-temp-dir> pnpm run check`
- 140 test files and 1,899 tests passed
- real-worker E2E covers the bounded prefix, run-local path, failure reason, and owner-only permissions
- fresh `pnpm run build` completed as part of `pnpm run check`

Closes #65
