### PR TITLE
feat(pi-tools): honor a per-call cwd on pi.bash

### DIFF
--- a/src/providers/pi-bash-cwd.ts
+++ b/src/providers/pi-bash-cwd.ts
@@ -1,0 +1,149 @@
+import { accessSync, constants, statSync } from "node:fs";
+import path from "node:path";
+import { createBashToolDefinition, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Type, type TSchema } from "typebox";
+
+// pi.bash's per-call execution directory.
+//
+// pi's shell backend already takes cwd as a first-class parameter
+// (BashOperations.exec(command, cwd, options)), and pi-agent-core's harness
+// shell goes further with a per-command ShellExecOptions.cwd. Only the bash
+// *tool schema* omits it, so a model-supplied cwd is dropped without a word by
+// pi core and rejected outright by Fabric's guest type check. Accepting the
+// field therefore has to come with honoring it, or the rejections would turn
+// into commands silently running in the wrong directory.
+//
+// The alternative — telling models to write `cd <dir> && <command>` — buries
+// the directory in the command string, where it defeats extensions that match
+// on command names (permission prompts, sandboxing) and hides the target from
+// Fabric's own approval classifier.
+
+export const PI_BASH_CWD_KEY = "cwd";
+
+/**
+ * Resolve and validate a single bash call's execution directory.
+ *
+ * Relative paths resolve against the session cwd. Unlike the leaf-agent
+ * resolver this deliberately does NOT canonicalize symlinks: agents commonly
+ * target git worktrees whose paths are symlinks, and rewriting those to their
+ * real targets changes what `pwd` reports inside the command and breaks
+ * tooling that keys on the worktree path. `path.resolve` normalizes `..`
+ * lexically, which is all the approval classifier needs to see a truthful
+ * absolute target.
+ *
+ * Containment is intentionally not enforced. Models can already reach any
+ * directory with `cd <dir> && <command>`, which Fabric neither inspects nor
+ * contains, so a containment check here would add no boundary — it would only
+ * push calls back into the string-concatenated form that evades it. Directory
+ * containment belongs to pi's project-trust layer or a bash spawn hook.
+ */
+export const resolvePiBashCwd = (sessionCwd: string, requested: unknown): string => {
+  if (typeof requested !== "string" || requested.trim().length === 0) {
+    throw new Error(
+      `Invalid pi.bash cwd ${JSON.stringify(requested)}: path must be a non-empty string`,
+    );
+  }
+  const resolved = path.isAbsolute(requested)
+    ? path.resolve(requested)
+    : path.resolve(sessionCwd, requested);
+  try {
+    if (!statSync(resolved).isDirectory()) throw new Error("path is not a directory");
+    accessSync(resolved, constants.R_OK | constants.X_OK);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid pi.bash cwd ${JSON.stringify(requested)} (${resolved}): ${reason}`);
+  }
+  return resolved;
+};
+
+/**
+ * Rewrite a bash call's cwd in place, leaving every other argument untouched.
+ *
+ * The arguments are never split into an execution copy: pi's bash schema
+ * declares no additionalProperties and its execute destructures
+ * { command, timeout }, so the extra key is inert there, while events,
+ * approval, and previews all benefit from seeing it. Resolving at the
+ * preparation stage means an unusable directory fails before validation and
+ * before approval — no prompt, nothing executed — and everything downstream
+ * reads the resolved absolute path instead of the model's `../..` spelling,
+ * so an obfuscated target cannot pass for a harmless one.
+ */
+export const resolveBashCwdArgument = (
+  sessionCwd: string,
+  args: Record<string, unknown>,
+): Record<string, unknown> =>
+  Object.hasOwn(args, PI_BASH_CWD_KEY)
+    ? { ...args, [PI_BASH_CWD_KEY]: resolvePiBashCwd(sessionCwd, args[PI_BASH_CWD_KEY]) }
+    : args;
+
+const CWD_PROPERTY = Type.Optional(
+  Type.String({
+    description:
+      "Execution directory for this command; relative paths resolve from the session cwd.",
+  }),
+);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Declare `cwd` on the bash descriptor.
+ *
+ * Not load-bearing for validation — pi's bash schema sets no
+ * additionalProperties, so an undeclared cwd would pass anyway. It is declared
+ * because the descriptor is the contract the capability surface, the generated
+ * guest declarations, and the approval classifier all read; a tool that
+ * quietly honors a field it does not advertise is the next person's trap.
+ *
+ * Rebuilt as a fresh TObject rather than spread-cloned: TypeBox schemas carry
+ * Symbol keys that a spread drops, which would leave Value.Check unable to
+ * validate the descriptor at all. Property values are reused by reference, so
+ * they keep their own Symbols.
+ */
+export const withBashCwdSchema = (schema: unknown): unknown => {
+  if (!isRecord(schema) || !isRecord(schema.properties)) return schema;
+  if (Object.hasOwn(schema.properties, PI_BASH_CWD_KEY)) return schema;
+  const { type: _type, properties, required, ...rest } = schema;
+  return Type.Object(
+    { ...properties, [PI_BASH_CWD_KEY]: CWD_PROPERTY } as Record<string, TSchema>,
+    { ...rest, ...(Array.isArray(required) ? { required } : {}) },
+  );
+};
+
+// Bash definitions are cheap closure-holding objects, but one per distinct
+// directory still beats rebuilding on every call in a loop over one tree.
+const MAX_CACHED_DEFINITIONS = 16;
+
+/**
+ * Bash definitions bound to an execution directory.
+ *
+ * This class is the whole seam between Fabric's per-call cwd and pi's
+ * cwd-bound tool family: `createBashToolDefinition(cwd)`'s argument is what
+ * reaches spawn context and then BashOperations.exec. If pi-coding-agent ever
+ * honors ExtensionContext.cwd (earendil-works/pi#8679), or Fabric moves onto
+ * pi-agent-core's harness tools where the execution environment already
+ * carries cwd, this collapses to passing cwd through the context and the class
+ * goes away — the guest-facing `pi.bash({ command, cwd })` contract is
+ * unaffected either way.
+ */
+export class BashCwdDefinitions {
+  readonly #cache = new Map<string, ToolDefinition<any, any, any>>();
+
+  /** A bash definition bound to `cwd`, reusing a recent one when possible. */
+  get(cwd: string): ToolDefinition<any, any, any> {
+    const cached = this.#cache.get(cwd);
+    if (cached) {
+      // Refresh recency so a hot directory survives eviction.
+      this.#cache.delete(cwd);
+      this.#cache.set(cwd, cached);
+      return cached;
+    }
+    const definition = createBashToolDefinition(cwd);
+    this.#cache.set(cwd, definition);
+    if (this.#cache.size > MAX_CACHED_DEFINITIONS) {
+      const oldest = this.#cache.keys().next();
+      if (!oldest.done) this.#cache.delete(oldest.value);
+    }
+    return definition;
+  }
+}

--- a/src/providers/pi-tools-provider.ts
+++ b/src/providers/pi-tools-provider.ts
@@ -25,6 +25,12 @@ import type {
 } from "../protocol.js";
 import { countContentLines } from "../ui/preview-lines.js";
 import { CapturedToolsProvider } from "./captured-tools-provider.js";
+import {
+  BashCwdDefinitions,
+  PI_BASH_CWD_KEY,
+  resolveBashCwdArgument,
+  withBashCwdSchema,
+} from "./pi-bash-cwd.js";
 import { writeContentForPreview } from "./write-diff-limits.js";
 import { createPreviewWriteToolDefinition } from "./write-preview.js";
 
@@ -172,6 +178,7 @@ export class PiToolsProvider implements FabricProvider {
   readonly #catalog: CapturedToolCatalog | undefined;
   readonly #capturedTools: CapturedToolsProvider | undefined;
   readonly #cwd: string;
+  readonly #bashDefinitions = new BashCwdDefinitions();
 
   constructor(
     cwd: string,
@@ -233,6 +240,7 @@ export class PiToolsProvider implements FabricProvider {
       throw new Error(`Pi tool ${actionName} prepared non-object arguments`);
     }
     const record = prepared as Record<string, unknown>;
+    if (actionName === "bash") return resolveBashCwdArgument(this.#cwd, record);
     const hasPerEditAll = actionName === "edit"
       && Array.isArray(record.edits)
       && record.edits.some(
@@ -242,6 +250,18 @@ export class PiToolsProvider implements FabricProvider {
     return actionName === "edit" && (args.all === true || hasPerEditAll)
       ? expandReplaceAllEdit(this.#cwd, record, args.all === true)
       : record;
+  }
+
+  // The tool definition carrying this call's execution directory. Read-only:
+  // `cwd` stays in the arguments so events, approval, and previews see it, and
+  // pi's bash ignores the extra key.
+  #definitionFor(
+    name: PiCoreToolName,
+    args: Record<string, unknown>,
+  ): ToolDefinition<any, any, any> {
+    if (name !== "bash") return this.#tools[name];
+    const cwd = args[PI_BASH_CWD_KEY];
+    return typeof cwd === "string" ? this.#bashDefinitions.get(cwd) : this.#tools.bash;
   }
 
   async invoke(
@@ -261,7 +281,7 @@ export class PiToolsProvider implements FabricProvider {
       this.#attachPreview(name, result, args, context);
       return this.#normalizeResult(name, result, args);
     }
-    const tool = this.#tools[name];
+    const tool = this.#definitionFor(name, args);
     const runner = this.#catalog?.runner;
     // Without a runner (e.g. before the first tool refresh populated the
     // catalog) fall back to a direct execute — no extension hooks fire, but
@@ -535,10 +555,11 @@ export class PiToolsProvider implements FabricProvider {
     name: PiCoreToolName,
     tool: ToolDefinition<any, any, any>,
   ): FabricActionDescriptor {
+    const inputSchema = name === "bash" ? withBashCwdSchema(tool.parameters) : tool.parameters;
     return {
       name,
       description: tool.description,
-      inputSchema: tool.parameters as unknown as Record<string, unknown>,
+      inputSchema: inputSchema as unknown as Record<string, unknown>,
       risk: riskForTool(name),
       namespace: "builtin",
     };

--- a/src/runtime/guest-types.ts
+++ b/src/runtime/guest-types.ts
@@ -448,7 +448,15 @@ type PiFindPatternArgument = { pattern?: string; query?: string; regex?: string;
 // aliases belong here (max/start/ctx/ic/...), never primary-field aliases —
 // the primary field comes from the positional string.
 type PiReadOptions = { offset?: number; limit?: number; start?: number; max?: number };
-type PiBashOptions = { timeout?: number; timeoutMs?: number; settle?: boolean };
+// cwd is honored per call by the pi provider, which binds the command to a
+// bash definition rooted there; relative paths resolve from the session cwd.
+// The alias spellings mirror __piArgAliases.bash in quickjs-runtime.ts: the
+// runtime repairs them, so the checker has to accept the same spellings or a
+// repairable call is rejected before it ever reaches the sandbox.
+type PiBashOptions = {
+  timeout?: number; timeoutMs?: number; settle?: boolean;
+  cwd?: string; workdir?: string; directory?: string; workingDirectory?: string;
+};
 type PiGrepOptions = { path?: string; glob?: string; globPattern?: string; ignoreCase?: boolean; ic?: boolean; caseInsensitive?: boolean; literal?: boolean; context?: number; ctx?: number; limit?: number; max?: number };
 type PiFindOptions = { path?: string; limit?: number; max?: number };
 type PiLsOptions = { limit?: number; max?: number };

--- a/src/runtime/quickjs-runtime.ts
+++ b/src/runtime/quickjs-runtime.ts
@@ -117,6 +117,7 @@ const __piArgAliases = {
   bash: {
     cmd: "command", shell: "command", cmdline: "command", script: "command",
     commandLine: "command",
+    workdir: "cwd", directory: "cwd", workingDirectory: "cwd",
   },
   find: {
     query: "pattern", regex: "pattern", search: "pattern", name: "pattern",

--- a/tests/core-override-execution.test.ts
+++ b/tests/core-override-execution.test.ts
@@ -96,6 +96,39 @@ const setup = (
 };
 
 describe("captured core overrides through Fabric execution", () => {
+  it("fails closed instead of bypassing a bash override that does not support cwd", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fabric-core-bash-cwd-"));
+    const calls: Array<Record<string, unknown>> = [];
+    const override = makeOverride(
+      "bash",
+      Type.Object({ command: Type.String() }, { additionalProperties: false }),
+      calls,
+      "bash-override",
+    );
+    const { catalog, service } = setup(cwd, [override]);
+    try {
+      const result = await service.execute({
+        code: 'return pi.bash({ command: "echo TEST", cwd: "." });',
+        signal: undefined,
+        parentToolCallId: "core-bash-cwd-override",
+        context: makeContext(cwd),
+        onPartial() {},
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid arguments for pi.bash");
+      expect(result.error).toContain("cwd");
+      expect(result.trace.operations[0]).toMatchObject({
+        ref: "pi.bash",
+        failureStage: "validate",
+      });
+      expect(calls).toEqual([]);
+    } finally {
+      catalog.clear();
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("type-checks and invokes additive read forms while preserving shorthand and strings", async () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fabric-core-read-"));
     const calls: Array<Record<string, unknown>> = [];

--- a/tests/pi-bash-cwd.test.ts
+++ b/tests/pi-bash-cwd.test.ts
@@ -42,15 +42,30 @@ describe("resolvePiBashCwd", () => {
     expect(resolvePiBashCwd(nested, "../..")).toBe(root);
   });
 
-  // Worktree paths are frequently symlinks. Canonicalizing them would change
-  // what `pwd` reports inside the command and break tooling that keys on the
-  // worktree path, so the resolver stays lexical.
+  // Worktree paths are frequently symlinks. Keep the requested lexical path
+  // available to Fabric's audit/approval surfaces; the spawned shell may still
+  // report the physical target from `pwd`, so this is not a logical-PWD guarantee.
   it("preserves a symlinked directory instead of canonicalizing it", () => {
     const { root, nested } = makeTree();
     const link = path.join(root, "worktree-link");
     fs.symlinkSync(nested, link, "dir");
     expect(resolvePiBashCwd(root, "worktree-link")).toBe(link);
     expect(resolvePiBashCwd(root, "worktree-link")).not.toBe(nested);
+  });
+
+  it("executes through a symlink without promising the shell's pwd spelling", async () => {
+    const { root, nested } = makeTree();
+    const link = path.join(root, "worktree-link");
+    fs.symlinkSync(nested, link, "dir");
+    const result = await new BashCwdDefinitions().get(link).execute(
+      "pi-bash-cwd-symlink-test",
+      { command: "pwd" },
+      undefined,
+      () => {},
+      undefined as never,
+    );
+    const reported = (result.content[0] as { text: string }).text.trim();
+    expect(fs.realpathSync(reported)).toBe(fs.realpathSync(link));
   });
 
   it("names the resolved path when the directory is missing", () => {

--- a/tests/pi-bash-cwd.test.ts
+++ b/tests/pi-bash-cwd.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createBashToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Value } from "typebox/value";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  BashCwdDefinitions,
+  resolveBashCwdArgument,
+  resolvePiBashCwd,
+  withBashCwdSchema,
+} from "../src/providers/pi-bash-cwd.js";
+
+const roots: string[] = [];
+
+const makeTree = (): { root: string; nested: string } => {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "pi-bash-cwd-")));
+  roots.push(root);
+  const nested = path.join(root, "services", "link");
+  fs.mkdirSync(nested, { recursive: true });
+  return { root, nested };
+};
+
+afterAll(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("resolvePiBashCwd", () => {
+  it("resolves a relative path against the session cwd", () => {
+    const { root, nested } = makeTree();
+    expect(resolvePiBashCwd(root, "services/link")).toBe(nested);
+  });
+
+  it("accepts an absolute path outside the session cwd", () => {
+    const { root } = makeTree();
+    const { nested: elsewhere } = makeTree();
+    expect(resolvePiBashCwd(root, elsewhere)).toBe(elsewhere);
+  });
+
+  it("normalizes parent traversal without rejecting it", () => {
+    const { root, nested } = makeTree();
+    expect(resolvePiBashCwd(nested, "../..")).toBe(root);
+  });
+
+  // Worktree paths are frequently symlinks. Canonicalizing them would change
+  // what `pwd` reports inside the command and break tooling that keys on the
+  // worktree path, so the resolver stays lexical.
+  it("preserves a symlinked directory instead of canonicalizing it", () => {
+    const { root, nested } = makeTree();
+    const link = path.join(root, "worktree-link");
+    fs.symlinkSync(nested, link, "dir");
+    expect(resolvePiBashCwd(root, "worktree-link")).toBe(link);
+    expect(resolvePiBashCwd(root, "worktree-link")).not.toBe(nested);
+  });
+
+  it("names the resolved path when the directory is missing", () => {
+    const { root } = makeTree();
+    expect(() => resolvePiBashCwd(root, "nope")).toThrowError(
+      new RegExp(`Invalid pi\\.bash cwd "nope" \\(${root}/nope\\)`),
+    );
+  });
+
+  it("rejects a file", () => {
+    const { root } = makeTree();
+    const file = path.join(root, "README.md");
+    fs.writeFileSync(file, "test\n");
+    expect(() => resolvePiBashCwd(root, file)).toThrowError(/path is not a directory/);
+  });
+
+  it("rejects an empty or non-string path", () => {
+    const { root } = makeTree();
+    expect(() => resolvePiBashCwd(root, "   ")).toThrowError(/must be a non-empty string/);
+    expect(() => resolvePiBashCwd(root, 5)).toThrowError(/must be a non-empty string/);
+    expect(() => resolvePiBashCwd(root, undefined)).toThrowError(/must be a non-empty string/);
+  });
+});
+
+describe("resolveBashCwdArgument", () => {
+  it("returns the same object when no cwd is present", () => {
+    const { root } = makeTree();
+    const args = { command: "pwd" };
+    expect(resolveBashCwdArgument(root, args)).toBe(args);
+  });
+
+  it("rewrites cwd in place and leaves other arguments untouched", () => {
+    const { root, nested } = makeTree();
+    expect(resolveBashCwdArgument(root, { command: "pwd", timeout: 5, cwd: "services/link" }))
+      .toEqual({ command: "pwd", timeout: 5, cwd: nested });
+  });
+
+  it("fails before execution when the directory is unusable", () => {
+    const { root } = makeTree();
+    expect(() => resolveBashCwdArgument(root, { command: "pwd", cwd: "nope" })).toThrow();
+  });
+});
+
+describe("withBashCwdSchema", () => {
+  const schema = withBashCwdSchema(
+    createBashToolDefinition("/").parameters,
+  ) as Record<string, unknown>;
+
+  it("declares cwd on the descriptor", () => {
+    expect(Object.keys((schema as { properties: object }).properties)).toContain("cwd");
+  });
+
+  it("stays a working TypeBox schema", () => {
+    expect(Value.Check(schema, { command: "pwd" })).toBe(true);
+    expect(Value.Check(schema, { command: "pwd", cwd: "/tmp" })).toBe(true);
+    expect(Value.Check(schema, { command: "pwd", cwd: 5 })).toBe(false);
+    expect(Value.Check(schema, { cwd: "/tmp" })).toBe(false);
+  });
+
+  it("is idempotent", () => {
+    expect(withBashCwdSchema(schema)).toBe(schema);
+  });
+});
+
+describe("BashCwdDefinitions", () => {
+  it("reuses the definition for a repeated directory", () => {
+    const definitions = new BashCwdDefinitions();
+    expect(definitions.get("/tmp")).toBe(definitions.get("/tmp"));
+  });
+
+  it("keeps distinct directories distinct", () => {
+    const definitions = new BashCwdDefinitions();
+    expect(definitions.get("/tmp")).not.toBe(definitions.get("/"));
+  });
+
+  // The whole point of binding a definition: the factory argument is what
+  // reaches spawn context and then the shell backend.
+  it("runs the command in the bound directory", async () => {
+    const { nested } = makeTree();
+    const definitions = new BashCwdDefinitions();
+    const result = await definitions.get(nested).execute(
+      "pi-bash-cwd-test",
+      { command: "pwd" },
+      undefined,
+      () => {},
+      undefined as never,
+    );
+    expect(result.content[0]).toMatchObject({ text: expect.stringContaining(nested) });
+  });
+
+  // Guards the regression this change exists to prevent: declaring cwd in the
+  // guest types without honoring it would turn a type rejection into a command
+  // silently running in the session directory.
+  it("is required — pi's stock definition ignores a cwd argument", async () => {
+    const { root, nested } = makeTree();
+    const result = await createBashToolDefinition(root).execute(
+      "pi-bash-cwd-test",
+      { command: "pwd", cwd: nested } as never,
+      undefined,
+      () => {},
+      undefined as never,
+    );
+    expect(result.content[0]).toMatchObject({ text: expect.stringContaining(root) });
+    expect((result.content[0] as { text: string }).text).not.toContain(nested);
+  });
+});


### PR DESCRIPTION
Closes the `cwd` half of #50 — and revises the approach I proposed there. That
issue asked to keep `cwd` unsupported and add a recovery hint; a larger sample
and two pieces of newer evidence changed my mind, and I'm posting the reasoning
rather than quietly switching.

## Problem

Models routinely transfer `cwd` from other shell tools into `pi.bash`. The
guest type check refuses it:

```
Object literal may only specify known properties, and 'cwd' does not exist in
type 'PiCommandArgument & PiBashOptions'.
```

Across **7,252 recorded `fabric_exec` calls** (145 session files,
2026-08-19 → 08-27, pi-fabric 0.61.2, pi 0.84.3, `gpt-5.6-sol` /
`gpt-5.6-terra`), 136 calls were rejected at type check with nothing executed.
Their root causes:

| Root cause | Count |
|---|---|
| Syntax / embedded-text quoting | 81 |
| **Unsupported property** | **35** |
| Unavailable global or variable | 13 |
| Other | 7 |

Within the unsupported-property class, `cwd` on `pi.bash` accounts for **26 of
the 136 rejections — the largest single identifiable root cause in the set.**
Every one costs a model round trip and produces nothing.

## Why not a recovery hint

The hint I originally proposed was `pi.bash("cd <dir> && <command>")`.

1. That is the pattern earendil-works/pi#7241 argued against on pi's own bash
   tool: it makes the command harder to read and *interferes with extensions
   that match on command names* (permission prompts, sandboxing).
2. #68 — explicitly filed as the same class as #50 — reports a model ignoring a
   recovery hint 10+ times in a session whose context already contained the
   rule. Hints are a prompt-shaped fix that has to keep working across every
   future model revision, and the failure here is attention, not knowledge.

## What this does

`cwd` is already a first-class parameter of pi's shell backend —
`BashOperations.exec(command, cwd, options)` — and pi-agent-core's harness
shell goes further with a per-command `ShellExecOptions.cwd`. Only the bash
*tool schema* omits it. So this needs no shell-string rewriting and no
escaping: the value is validated and passed through, never concatenated into a
command.

- `PiBashOptions` declares `cwd`, plus the alias spellings `workdir`,
  `directory`, `workingDirectory`
- `__piArgAliases.bash` repairs those aliases, matching that table's own
  instruction to stay in sync with the guest declarations
- The pi provider resolves and validates `cwd` at the preparation stage, then
  binds the call to a bash definition rooted there

**Declaring the field and honoring it land in the same commit on purpose.**
Declaring it alone would convert a type rejection into a command silently
running in the session directory — strictly worse than today. A test asserts
that pi's stock bash definition ignores a `cwd` argument, so that regression
cannot creep back in.

`cwd` stays in the arguments rather than being split into an execution copy:
pi's bash schema declares no `additionalProperties` and its `execute`
destructures `{ command, timeout }`, so the extra key is inert there, while
extension events, the approval classifier, and previews all benefit from seeing
it. Resolving during preparation means an unusable directory fails *before*
validation and *before* approval — no prompt, nothing executed — and everything
downstream reads the resolved absolute path rather than the model's `../..`
spelling.

## Two deliberate departures from #48

#48 (`feat(agents): add target cwd for leaf agents`) set the shape here, and I
followed it including its stance of adding no new trust gate. Two differences,
both intentional:

**No symlink canonicalization.** `resolveAgentCwd` needs a stable identity for
worktree leases and residency. Bash does not, and agents frequently target git
worktrees whose paths are symlinks. Fabric preserves the requested lexical path
for its audit and approval surfaces instead of erasing that identity itself.
The spawned OS/shell may still report the physical target from `pwd`; this is
deliberately not a logical-PWD guarantee. The end-to-end symlink test verifies
that execution reaches the same real directory. `path.resolve` normalizes
`..` lexically, which is what the approval classifier needs to see as the
requested absolute target.

**No containment check.** Models can already reach any directory with
`cd <dir> && <command>`, which Fabric neither inspects nor contains. A
containment check on `cwd` would add no boundary — it would only push calls
back into the string-concatenated form that evades it. Containment belongs to
pi's project-trust layer or a bash spawn hook. In the recorded data this
matters: the most common absolute value was a git worktree outside the session
cwd (6 occurrences), and 13 of 22 literal values were relative paths.

## Validation

- `pnpm run typecheck`, `build`, `assert:lazy-graph`, `lint:dead` — clean
- `pnpm run test` — 154 files, 2,068 tests, no skips
- 19 new tests across `tests/pi-bash-cwd.test.ts` and
  `tests/core-override-execution.test.ts`, including the stock-definition
  regression guard, process-level symlink coverage, and captured Bash override
  fail-closed coverage
- Replaying the 136 recorded static rejections against the patched guest
  declarations **clears 22, with no other rejection changing state**. Of the 28
  that named `cwd` / `workdir` / `stdin`, 22 clear; the remaining 6 are `stdin`
  (3) and `Cannot find name 'process'` (3), both out of scope here.

### Automated acceptance

A matched local A/B used Pi 0.84.3 and `openai-codex/gpt-5.6-sol:medium`
across five cwd-focused prompts. Baseline was `origin/main` at `3bd4ae7`;
candidate was this branch. This is a targeted compatibility acceptance run,
not a general Fabric performance benchmark.

| Metric | Baseline | Candidate |
|---|---:|---:|
| Functionally correct | 4/5 | **5/5** |
| Correct on the first Fabric call | 0/5 | **5/5** |
| Static type rejections | 6 | **0** |
| Total `fabric_exec` calls | 22 | **5** |
| Mean wall time | 58.7 s | **14.3 s** |
| Median wall time | 50.2 s | **14.9 s** |
| Processed model tokens | 167,287 | **19,720** |

The cases covered relative `cwd`, the `workdir` alias, two concurrent
working directories, a symlinked directory, and an invalid directory that had
to fail before command execution. The candidate removed every static rejection
and reduced mean wall time by about 76%, Fabric calls by about 77%, and processed
tokens by about 88% on this targeted set.

A separate captured-core-override acceptance probe registered a strict Bash
override whose schema does not include `cwd`. Fabric rejected `cwd` during
authoritative validation, did not invoke the override, and did not fall back to
the built-in Bash implementation. That behavior is now covered by an automated
regression test.

## Dogfooding

I'm running this build as my daily driver from 2026-08-27, replacing
`npm:pi-fabric@0.61.2` in `~/.pi/agent/settings.json` with the local checkout.
The baseline to beat is the 26 `cwd` rejections above; I'll report the live
figure here once there's a comparable window. Live checks so far cover absolute
paths, relative paths, the `workdir` alias, and the no-`cwd` case (unchanged).

Happy to split the alias spellings out, drop them entirely, or narrow the scope
if you'd rather land something smaller. `stdin` is deliberately excluded — pi's
`exec` has no stdin channel, so it would need a temp-file transport.
