### PR TITLE
fix(capture): rebuild catalog on re-enable; surface extension tool roster

### DIFF
--- a/src/capture/catalog.ts
+++ b/src/capture/catalog.ts
@@ -62,6 +62,15 @@ export class CapturedToolCatalog {
     this.#emit();
   }
 
+  // Re-run the capture pass against the last observed runner. During /reload
+  // the hub listener fires while capture is still suspended, so the catalog
+  // replaces with enabled:false and ends up empty once session_start
+  // re-enables it (#73). This forces a fresh replace with the active policy
+  // without waiting for pi to call getAllRegisteredTools() again.
+  refresh(): void {
+    this.#runner?.getAllRegisteredTools();
+  }
+
   subscribe(listener: () => void): () => void {
     this.#listeners.add(listener);
     return () => this.#listeners.delete(listener);

--- a/src/core/system-guidance.ts
+++ b/src/core/system-guidance.ts
@@ -8,6 +8,33 @@ export const defaultFabricExecutionGuidance = (fullCodeMode: boolean): string =>
     ? "Examples and returns: `pi.read('/x')`, `pi.grep('TODO','src')` / `pi.grep({pattern:'TODO', path:'src', ignoreCase:true, context:2})`, `pi.find({pattern:'*.ts', path:'src', limit:20})`, and `pi.ls('src')` return strings; `pi.bash({cmd:'ls'})`, `pi.edit({path:'/x', old:'a', new:'b'})`, and `pi.write({path:'/y', text:'z'})` return `{ok, output, details}` (read `.output`); failed core calls reject, including `bash` on an ordinary nonzero exit; pass `settle: true` to `pi.bash` to get `{ ok: false, exitCode, output, error }` instead. Timeout, cancellation, approval, and security failures still reject.\n`tools` is discovery + generic calls only (`providers`/`catalog`/`list`/`search`/`describe`/`call`/`models`). Call known MCP tools as `mcp.<sanitized_server>.<sanitized_tool>(args)`, captured tools as `extensions.<tool>(args)`, and stable providers as `memory.*`, `state.*`, `schema.*`, or `compact.*`. Use `tools.call({ref,args})` for computed refs. `pi` is the core tools; `π.<key>` reads named `strings` (not a tool)."
     : "Call known actions through `mcp.<sanitized_server>.<sanitized_tool>(args)`, `memory.*`, `state.*`, `schema.*`, `components.*`, `compact.*`, `agents.*`, or `mesh.*`; use `tools.catalog`/`search`/`describe`/`list` for discovery and `tools.call({ref,args})` for computed refs. Other surfaces are opt-in via user-loaded skills.";
 
+// Shape of CapturedToolCatalog entries this renderer needs (kept structural to avoid a runtime dependency on the capture layer from a guidance module).
+export interface ExtensionRosterToolSource {
+  name: string;
+  definition: { description?: string };
+}
+
+// In full code mode the model sees only fabric_exec in its tool list, so
+// registered extension tools are invisible unless named up front (#69). Core
+// overrides are excluded: they surface as pi.* via coreOverridePromptGuidance.
+export const extensionToolRosterGuidance = (
+  tools: ReadonlyArray<ExtensionRosterToolSource>,
+  coreToolNames: ReadonlySet<string>,
+): string | undefined => {
+  const extensionTools = tools.filter((tool) => !coreToolNames.has(tool.name));
+  if (extensionTools.length === 0) return undefined;
+  const lines = extensionTools.map((tool) => {
+    const summary = (tool.definition.description ?? "").split("\n")[0]?.trim() ?? "";
+    const label = "- `extensions." + tool.name + "()`";
+    return summary ? label + ": " + summary.slice(0, 120) : label;
+  });
+  return [
+    "Registered extension tools are callable inside fabric_exec as `extensions.<name>(args)` and via `extensions.list` for discovery.",
+    "Prefer a purpose-built extension tool over re-implementing its effect with pi.bash:",
+    ...lines,
+  ].join("\n");
+};
+
 export const fabricSchemaGuidance = (mode: "off" | "audit" | "enforce"): string | undefined => {
   if (mode === "enforce") {
     return "Schema enforce mode is fixed for this session. Reads remain available, but protected-workspace changes must use schema.hypothesize → schema.verify → schema.commit in the same fabric_exec invocation. Direct pi.edit/write/bash, agents, state/mesh writes, compaction requests, MCP, extensions, and external providers are blocked by the host gate.";

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,10 +36,12 @@ import {
   expandSkillDirMarkersInSkillBlock,
 } from "./core/skill-dir.js";
 import { coreOverridePromptGuidance } from "./core/core-override-guidance.js";
+import { PI_CORE_TOOL_NAMES } from "./core/pi-tools.js";
 import {
   fabricExecutionKernelGuidance,
   defaultFabricExecutionGuidance,
   fabricSchemaGuidance,
+  extensionToolRosterGuidance,
 } from "./core/system-guidance.js";
 import {
   FABRIC_EXECUTION_GUIDANCE_SLOT,
@@ -308,6 +310,7 @@ export default async function piFabric(pi: ExtensionAPI): Promise<void> {
       fabricOwnsModelTools(),
       fabricOwnsModelTools() ? hiddenCapturedToolNames() : undefined,
     );
+    capturedTools.refresh();
     refreshAdvisorSources();
   };
   const suspendToolCapture = (): void => {
@@ -738,6 +741,9 @@ export default async function piFabric(pi: ExtensionAPI): Promise<void> {
     const overrideGuidance = effectiveFullCodeMode
       ? coreOverridePromptGuidance(capturedTools).trim()
       : undefined;
+    const extensionRoster = effectiveFullCodeMode
+      ? extensionToolRosterGuidance(capturedTools.list(), new Set(PI_CORE_TOOL_NAMES))
+      : undefined;
     // Only turn-stable sections go into the system prompt. Anything derived
     // from the current prompt (skill references, capability advisory) rides
     // the message channel so provider prefix caches never cold-prefill.
@@ -746,6 +752,7 @@ export default async function piFabric(pi: ExtensionAPI): Promise<void> {
       resolvedGuidance.slotText,
       fabricSchemaGuidance(schemaMode),
       overrideGuidance,
+      extensionRoster,
       resolvedGuidance.appendText,
     ].filter((section): section is string => Boolean(section)).join("\n\n");
     // One-shot capability steering: when the prompt's vocabulary matches a

--- a/src/runtime/quickjs-runtime.ts
+++ b/src/runtime/quickjs-runtime.ts
@@ -42,6 +42,27 @@ type QuickJsModule = Awaited<ReturnType<typeof newQuickJSWASMModuleFromVariant>>
 
 let quickJsModulePromise: Promise<QuickJsModule> | undefined;
 
+// Static π.<identifier> references (bracket access like π[k] is not provable).
+const PI_REF_PATTERN = /(?:^|[^\w$.])π\.([A-Za-z_$][\w$]*)/g;
+
+// Models routinely reference π.<key> without providing the strings parameter,
+// and the runtime error only lands after a full execution round trip (#68).
+// Reject up front when a referenced key is statically provable missing, before
+// QuickJS is even loaded.
+const missingStringsKeys = (
+  code: string,
+  strings: Record<string, string> | undefined,
+): string[] => {
+  const provided = strings ?? {};
+  const missing: string[] = [];
+  for (const match of code.matchAll(PI_REF_PATTERN)) {
+    const key = match[1];
+    if (key === undefined || key in provided) continue;
+    if (!missing.includes(key)) missing.push(key);
+  }
+  return missing;
+};
+
 const quickJsModule = (): Promise<QuickJsModule> => {
   quickJsModulePromise ??= newQuickJSWASMModuleFromVariant(releaseSyncVariant);
   return quickJsModulePromise;
@@ -402,7 +423,8 @@ globalThis["π"] = new Proxy(__piStrings, {
     throw new Error(
       "π." + name + " is not defined. π only exposes keys from the fabric_exec strings parameter" +
       (provided.length ? " (provided: " + provided.join(", ") + ")" : " (none provided)") +
-      ". Pass strings: { " + name + ": '...' } to use π." + name + "."
+      ". Pass strings: { " + name + ": '...' } to use π." + name + "." +
+      " For large or quote-heavy content, keep it in top-level strings and reference π." + name + " instead of escaping it inside code."
     );
   },
   ownKeys(target) { return Reflect.ownKeys(target); },
@@ -796,6 +818,22 @@ export class QuickJsRuntime {
         logs: [],
         terminationReason: "aborted",
         error: "Execution cancelled",
+      };
+    }
+    const missingKeys = missingStringsKeys(code, options.strings);
+    if (missingKeys.length > 0) {
+      const provided = Object.keys(options.strings ?? {});
+      return {
+        value: undefined,
+        logs: [],
+        terminationReason: "runtime_error",
+        error:
+          "Pre-execution check: " + missingKeys.map((key) => "π." + key).join(", ")
+          + (missingKeys.length === 1 ? " is referenced in code but its key is missing from the strings parameter"
+            : " are referenced in code but their keys are missing from the strings parameter")
+          + (provided.length ? " (provided: " + provided.join(", ") + ")" : " (none provided)")
+          + ". Add strings: { " + missingKeys.join(": '...', ") + ": '...' } to the fabric_exec arguments, then reference the value as π.<key>."
+          + " For large or quote-heavy content, keep it in top-level strings and reference π.<key> instead of escaping it inside code.",
       };
     }
     if (

--- a/tests/extension-roster-guidance.test.ts
+++ b/tests/extension-roster-guidance.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { extensionToolRosterGuidance } from "../src/core/system-guidance.js";
+
+const entry = (name: string, description?: string) => ({
+  name,
+  ...(description === undefined ? { definition: {} } : { definition: { description } }),
+});
+
+describe("extensionToolRosterGuidance", () => {
+  it("lists extension tools with first-line descriptions", () => {
+    const roster = extensionToolRosterGuidance(
+      [entry("deploy_release", "Deploys the release.\nSecond line"), entry("ctx_read", "Reads context")],
+      new Set(["read", "bash"]),
+    );
+    expect(roster).toContain("`extensions.deploy_release()`: Deploys the release.");
+    expect(roster).toContain("`extensions.ctx_read()`");
+    expect(roster).not.toContain("Second line");
+    expect(roster).toContain("extensions.list");
+  });
+
+  it("excludes captured core overrides and empty catalogs", () => {
+    expect(extensionToolRosterGuidance([entry("read", "core override")], new Set(["read"]))).toBeUndefined();
+    expect(extensionToolRosterGuidance([], new Set())).toBeUndefined();
+  });
+
+  it("truncates overly long descriptions", () => {
+    const roster = extensionToolRosterGuidance(
+      [entry("big", "x".repeat(300))],
+      new Set(),
+    );
+    expect(roster).not.toContain("x".repeat(121));
+    expect(roster).toContain("x".repeat(120));
+  });
+});

--- a/tests/quickjs-runtime.test.ts
+++ b/tests/quickjs-runtime.test.ts
@@ -495,8 +495,62 @@ await Promise.all([
       async () => undefined,
       { ...options, strings: { content: "hello" } },
     );
-    expect(failed.error).toContain("π.previewFile is not defined");
-    expect(failed.error).toContain("provided: content");
+    expect(failed.error).toContain("Pre-execution check: π.previewFile is referenced");
+    expect(failed.error).toContain("(provided: content)");
+
+    const dynamic = await new QuickJsRuntime().execute(
+      `const k = "previewFile"; return π[k];`,
+      async () => undefined,
+      { ...options, strings: { content: "hello" } },
+    );
+    expect(dynamic.error).toContain("π.previewFile is not defined");
+    expect(dynamic.error).toContain("provided: content");
+  });
+
+  it("rejects π references to missing strings keys before execution (#68)", async () => {
+    const failed = await new QuickJsRuntime().execute(
+      'await pi.write({ path: "x.md", text: π.body });',
+      async () => {
+        throw new Error("host call must not run");
+      },
+      { ...options, strings: { other: "hello" } },
+    );
+    expect(failed.terminationReason).toBe("runtime_error");
+    expect(failed.error).toContain("Pre-execution check: π.body is referenced");
+    expect(failed.error).toContain("(provided: other)");
+    expect(failed.error).toContain("Add strings: { body: '...' }");
+
+    const none = await new QuickJsRuntime().execute(
+      'return π.summary;',
+      async () => {
+        throw new Error("host call must not run");
+      },
+      { ...options },
+    );
+    expect(none.error).toContain("(none provided)");
+
+    const multiple = await new QuickJsRuntime().execute(
+      'const a = π.alpha; const b = π.alpha; const c = π.beta;',
+      async () => undefined,
+      { ...options, strings: {} },
+    );
+    expect(multiple.error).toContain("π.alpha, π.beta are referenced");
+
+    const provided = await new QuickJsRuntime().execute(
+      'await pi.write({ path: "x.md", text: π.body }); return "ok";',
+      async () => undefined,
+      { ...options, strings: { body: "content" } },
+    );
+    expect(provided.terminationReason).toBe("completed");
+  });
+
+  it("does not flag bracket access or bare π on dynamic keys", async () => {
+    const result = await new QuickJsRuntime().execute(
+      'const key = "k"; return Object.keys(π).length + (π[key] === undefined ? 0 : 1);',
+      async () => undefined,
+      { ...options, strings: { k: "v" } },
+    );
+    expect(result.terminationReason).toBe("completed");
   });
 
   it("bridges tools.models() to the fabric.$models host call", async () => {

--- a/tests/tool-capture.test.ts
+++ b/tests/tool-capture.test.ts
@@ -85,6 +85,41 @@ describe("registered extension tool capture", () => {
     expect(catalog.size).toBe(0);
   });
 
+  it("refresh() repopulates after a suspended-pass clear, as on /reload (#73)", async () => {
+    const fabricTool = tool("fabric_exec");
+    const customTool = tool("deploy_release");
+    const runner = runnerWith(
+      registered(fabricTool, "/extensions/pi-fabric/index.ts"),
+      registered(customTool, "/extensions/pi-deploy/index.ts"),
+    );
+    const catalog = new CapturedToolCatalog();
+    const controller = await installRegisteredToolCapture({
+      anchorDefinition: fabricTool,
+      catalog,
+      initialPolicy: structuredClone(DEFAULT_FABRIC_CONFIG.capture),
+    });
+    controllers.push(controller);
+
+    runner.getAllRegisteredTools();
+    expect(catalog.get("deploy_release")).toBeDefined();
+
+    // session_start suspends capture, then /reload re-registers extensions and
+    // refreshes the tool registry while suspension is still active: the hub
+    // listener runs with enabled:false and clears the catalog.
+    controller.setPolicy({ ...structuredClone(DEFAULT_FABRIC_CONFIG.capture), enabled: false });
+    runner.getAllRegisteredTools();
+    expect(catalog.get("deploy_release")).toBeUndefined();
+
+    // session_start re-enables capture, but setPolicy(enabled) fires nothing —
+    // the catalog would stay empty until restart without a forced refresh.
+    controller.setPolicy(structuredClone(DEFAULT_FABRIC_CONFIG.capture));
+    expect(catalog.get("deploy_release")).toBeUndefined();
+
+    catalog.refresh();
+    expect(catalog.get("deploy_release")).toBeDefined();
+    expect(catalog.get("fabric_exec")).toBeUndefined();
+  });
+
   it("classifies Fovea's graph-navigation tools as read-only", () => {
     const definitions = [
       "fovea_sketch",


### PR DESCRIPTION
## Summary

Two related fixes for extension-tool visibility in full code mode.

### #73 — `/reload` no longer drops extension tools from the captured view

During `/reload`, pi rebuilds the runtime and refreshes the tool registry **before** emitting `session_start`. Fabric's `session_start` handler suspends capture first, so the capture-hub listener fires while capture is disabled — the catalog replaces with `enabled: false` and ends up empty. When `applyFabricMode()` re-enables capture, `setPolicy` fires nothing, so every `extensions.*` ref threw `Unknown Fabric action` until session restart.

Fix: `CapturedToolCatalog.refresh()` re-runs the capture pass against the last observed runner (kept even while disabled), and `applyFabricMode()` calls it after re-enabling — repopulating the catalog with the active policy and re-asserting tool ownership via the existing `onCatalogRefresh` hook.

### #69 — extension tools are named in ambient guidance

In full code mode the model sees only `fabric_exec`, so registered extension tools were invisible unless the model guessed. New `extensionToolRosterGuidance` injects a compact roster (`extensions.<name>()` + first-line description, truncated at 120 chars) into ambient guidance. Captured core overrides are excluded — they already surface as `pi.*` via `coreOverridePromptGuidance`.

Closes #73
Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)