### PR TITLE
fix(deps): override ajv>fast-uri to ^3.1.6 (CVE-2026-18446)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ajv>fast-uri: ^3.1.6
+
 importers:
 
   .:
@@ -1335,8 +1338,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
@@ -3138,7 +3141,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3365,7 +3368,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.6: {}
 
   fd-package-json@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - "."
 
+overrides:
+  "ajv>fast-uri": ^3.1.6
+
 allowBuilds:
   "@google/genai": true
   esbuild: true


### PR DESCRIPTION
## Summary

Bumps the transitive `fast-uri` dependency from 3.1.4 to 3.1.6 via a scoped pnpm override, clearing CVE-2026-18446 (HIGH: backslash-as-path-separator authority confusion enabling SSRF / open-redirect bypasses in host-allowlist scenarios).

## Why an override

`fast-uri` is not a direct dependency — it is reachable only through `ajv` ← `@modelcontextprotocol/sdk` ← `@earendil-works/pi-ai@0.84.4` (pi core's chain). ajv declares `^3.0.1`, so the patched 3.1.6 is in-range; a scoped `ajv>fast-uri` override in `pnpm-workspace.yaml` (pnpm ≥10 home for overrides) bumps it without touching pi core or the SDK.

## Exposure note

Fabric only consumes fast-uri indirectly through MCP SDK URL parsing — not the host-allowlist / SSRF-filter / redirect-validation paths the CVE targets — so severity here is low. Merged for hygiene.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)