### PR TITLE
fix(runtime): pre-validate π strings refs before execution

### DIFF
--- a/src/runtime/quickjs-runtime.ts
+++ b/src/runtime/quickjs-runtime.ts
@@ -42,6 +42,27 @@ type QuickJsModule = Awaited<ReturnType<typeof newQuickJSWASMModuleFromVariant>>
 
 let quickJsModulePromise: Promise<QuickJsModule> | undefined;
 
+// Static π.<identifier> references (bracket access like π[k] is not provable).
+const PI_REF_PATTERN = /(?:^|[^\w$.])π\.([A-Za-z_$][\w$]*)/g;
+
+// Models routinely reference π.<key> without providing the strings parameter,
+// and the runtime error only lands after a full execution round trip (#68).
+// Reject up front when a referenced key is statically provable missing, before
+// QuickJS is even loaded.
+const missingStringsKeys = (
+  code: string,
+  strings: Record<string, string> | undefined,
+): string[] => {
+  const provided = strings ?? {};
+  const missing: string[] = [];
+  for (const match of code.matchAll(PI_REF_PATTERN)) {
+    const key = match[1];
+    if (key === undefined || key in provided) continue;
+    if (!missing.includes(key)) missing.push(key);
+  }
+  return missing;
+};
+
 const quickJsModule = (): Promise<QuickJsModule> => {
   quickJsModulePromise ??= newQuickJSWASMModuleFromVariant(releaseSyncVariant);
   return quickJsModulePromise;
@@ -402,7 +423,8 @@ globalThis["π"] = new Proxy(__piStrings, {
     throw new Error(
       "π." + name + " is not defined. π only exposes keys from the fabric_exec strings parameter" +
       (provided.length ? " (provided: " + provided.join(", ") + ")" : " (none provided)") +
-      ". Pass strings: { " + name + ": '...' } to use π." + name + "."
+      ". Pass strings: { " + name + ": '...' } to use π." + name + "." +
+      " For large or quote-heavy content, keep it in top-level strings and reference π." + name + " instead of escaping it inside code."
     );
   },
   ownKeys(target) { return Reflect.ownKeys(target); },
@@ -796,6 +818,22 @@ export class QuickJsRuntime {
         logs: [],
         terminationReason: "aborted",
         error: "Execution cancelled",
+      };
+    }
+    const missingKeys = missingStringsKeys(code, options.strings);
+    if (missingKeys.length > 0) {
+      const provided = Object.keys(options.strings ?? {});
+      return {
+        value: undefined,
+        logs: [],
+        terminationReason: "runtime_error",
+        error:
+          "Pre-execution check: " + missingKeys.map((key) => "π." + key).join(", ")
+          + (missingKeys.length === 1 ? " is referenced in code but its key is missing from the strings parameter"
+            : " are referenced in code but their keys are missing from the strings parameter")
+          + (provided.length ? " (provided: " + provided.join(", ") + ")" : " (none provided)")
+          + ". Add strings: { " + missingKeys.join(": '...', ") + ": '...' } to the fabric_exec arguments, then reference the value as π.<key>."
+          + " For large or quote-heavy content, keep it in top-level strings and reference π.<key> instead of escaping it inside code.",
       };
     }
     if (

--- a/tests/quickjs-runtime.test.ts
+++ b/tests/quickjs-runtime.test.ts
@@ -495,8 +495,62 @@ await Promise.all([
       async () => undefined,
       { ...options, strings: { content: "hello" } },
     );
-    expect(failed.error).toContain("π.previewFile is not defined");
-    expect(failed.error).toContain("provided: content");
+    expect(failed.error).toContain("Pre-execution check: π.previewFile is referenced");
+    expect(failed.error).toContain("(provided: content)");
+
+    const dynamic = await new QuickJsRuntime().execute(
+      `const k = "previewFile"; return π[k];`,
+      async () => undefined,
+      { ...options, strings: { content: "hello" } },
+    );
+    expect(dynamic.error).toContain("π.previewFile is not defined");
+    expect(dynamic.error).toContain("provided: content");
+  });
+
+  it("rejects π references to missing strings keys before execution (#68)", async () => {
+    const failed = await new QuickJsRuntime().execute(
+      'await pi.write({ path: "x.md", text: π.body });',
+      async () => {
+        throw new Error("host call must not run");
+      },
+      { ...options, strings: { other: "hello" } },
+    );
+    expect(failed.terminationReason).toBe("runtime_error");
+    expect(failed.error).toContain("Pre-execution check: π.body is referenced");
+    expect(failed.error).toContain("(provided: other)");
+    expect(failed.error).toContain("Add strings: { body: '...' }");
+
+    const none = await new QuickJsRuntime().execute(
+      'return π.summary;',
+      async () => {
+        throw new Error("host call must not run");
+      },
+      { ...options },
+    );
+    expect(none.error).toContain("(none provided)");
+
+    const multiple = await new QuickJsRuntime().execute(
+      'const a = π.alpha; const b = π.alpha; const c = π.beta;',
+      async () => undefined,
+      { ...options, strings: {} },
+    );
+    expect(multiple.error).toContain("π.alpha, π.beta are referenced");
+
+    const provided = await new QuickJsRuntime().execute(
+      'await pi.write({ path: "x.md", text: π.body }); return "ok";',
+      async () => undefined,
+      { ...options, strings: { body: "content" } },
+    );
+    expect(provided.terminationReason).toBe("completed");
+  });
+
+  it("does not flag bracket access or bare π on dynamic keys", async () => {
+    const result = await new QuickJsRuntime().execute(
+      'const key = "k"; return Object.keys(π).length + (π[key] === undefined ? 0 : 1);',
+      async () => undefined,
+      { ...options, strings: { k: "v" } },
+    );
+    expect(result.terminationReason).toBe("completed");
   });
 
   it("bridges tools.models() to the fabric.$models host call", async () => {


### PR DESCRIPTION
## Summary

Adds pre-execution validation for `π.<key>` references: before QuickJS is even loaded, `QuickJsRuntime.execute` statically scans `code` for `π.<identifier>` accesses and rejects the call when a referenced key is missing from the `strings` parameter — with a recovery hint that names every missing key, shows the correct `strings` shape, and suggests keeping large content in top-level `strings` instead of escaping it inside `code`.

## Why

#68 documents (with a machine-readable failure catalog across multiple sessions) that models routinely generate `π.<key>` references while omitting the `strings` parameter entirely — even when the session context contains explicit rules about exactly this failure. The omission is structural: during retries the runtime error lands after a full execution round trip and the model's attention filters it out. Rejecting pre-execution collapses the failure loop to a single cheap, unmissable diagnostic.

Also extends the runtime proxy's `π.<key> is not defined` message with the same top-level-`strings` guidance.

## Notes

- Bracket access (`π[k]`) is not statically provable and still hits the runtime error path (covered by tests).
- Dynamic keys and `Object.keys(π)` are unaffected.
- The scan runs before WASM load, so rejected calls cost microseconds.

Closes #68 (failure mode A + C mitigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)