### PR TITLE
fix(runtime): preserve bash settle status through result middleware

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,6 +72,27 @@ For provider-level corruption, or for sessions that expose Pi tools directly, in
 
 The provider owns the Anthropic strict tool use setting. When enabled, strict mode stops the server from sampling keys that are absent from the schema. Anthropic limits the complexity of strict tool definitions.
 
+## Bash exit status and result middleware
+
+`pi.bash(..., { settle: true })` converts an ordinary native nonzero exit into
+`{ ok: false, exitCode, output, details, error }`. Fabric classifies that exit
+before `tool_result` middleware runs and transports the status separately from
+display text in both runtimes. Trimming, redaction, newline changes, or replacing
+the display text cannot erase the exit status. `output` and `error` use the final
+middleware text; they never restore text removed by a middleware. Native status
+line removal is best-effort display cleanup; ambiguous text is preserved.
+
+Timeout, cancellation, approval and preflight failures remain exceptions. A
+middleware failure after a successful command also remains an exception, and
+middleware recovery through `isError: false` remains effective. Pi's
+`emitToolResult` returns the **effective** `isError`, without identifying whether
+a handler introduced a new failure. After a native nonzero exit, Fabric cannot
+distinguish an annotation/redaction from an additional middleware veto expressed
+only through text and `isError: true`. Such a veto needs a separate explicit
+provenance contract; this limitation is not solved by bash settlement. For now,
+checks that must prevent command execution belong in approval or `tool_call`
+preflight, and callers requiring all final errors to throw should omit `settle`.
+
 ## Model-context economy
 
 Fabric caps final `fabric_exec` output at 50,000 characters by default, which matches Pi's built-in 50KB tool ceiling. Failed executions get a tighter 20,000-character visible ceiling, and the complete output stays in the same private artifact. An oversized structured return shares that budget across every multiline section and preserves both ends with explicit omission markers. Unstructured output keeps its global beginning and end. Fabric writes the complete output to a mode-`0600` temporary artifact and includes the artifact path inside the visible ceiling. The model can then retrieve a targeted range without carrying the entire result. Type-check diagnostics use the same ceiling. Models should still filter noisy commands and return only useful evidence, because source-side projection preserves more relevant information than post-format truncation. When a later nested call fails after earlier calls completed, the error adds a bounded list of completed refs and paths. The model can inspect that list before repeating side effects. Nested outputs the guest did not return are never exposed.

--- a/src/core/pi-bash-error.ts
+++ b/src/core/pi-bash-error.ts
@@ -1,0 +1,55 @@
+/** An ordinary bash exit, classified at the execute boundary before middleware. */
+class PiBashExitError extends Error {
+  constructor(message: string, readonly exitCode: number, readonly output: string) {
+    super(message);
+  }
+}
+
+// Pi currently exposes process status in its native exception text. Parse that
+// contract only at tool execution, never from a preflight/approval error or a
+// decorated tool_result. Keep the guest independent of display formatting.
+export function classifyPiBashError(error: unknown): unknown {
+  if (!(error instanceof Error)) return error;
+  const match = /(?:^|\n\n)Command exited with code (\d+)$/.exec(error.message);
+  if (!match) return error;
+  const exitCode = Number(match[1]);
+  if (!Number.isSafeInteger(exitCode) || exitCode <= 0) return error;
+  return new PiBashExitError(error.message, exitCode, error.message.slice(0, match.index));
+}
+
+// Display cleanup only: this never decides whether an error is a native exit.
+// Work exclusively with the final text so redacted/cleared content stays gone.
+function bashResultOutput(original: PiBashExitError, text: string): string {
+  const index = text.indexOf(original.message);
+  if (index >= 0) {
+    // The unchanged native message locates its status suffix unambiguously,
+    // even when stdout or annotations contain identical status-looking lines.
+    return text.slice(0, index + original.output.length) + text.slice(index + original.message.length);
+  }
+
+  // Middleware may trim, redact, split content blocks, or normalize newlines.
+  // Remove a remaining native status line only when there is one candidate.
+  // With no marker or multiple candidates, return the processed text verbatim.
+  const marker = new RegExp(`(?:^|\\r?\\n\\r?\\n)Command exited with code ${original.exitCode}(?=\\r?\\n|$)`, "g");
+  const match = marker.exec(text);
+  if (!match || marker.exec(text)) return text;
+  return text.slice(0, match.index) + text.slice(match.index + match[0].length);
+}
+
+/** Keep native exit status independent of middleware display transformations. */
+export function piBashResultError(original: unknown, text: string): Error {
+  if (original instanceof PiBashExitError) {
+    // Pi returns only the effective isError, not the origin of a middleware
+    // veto. Text replacement alone cannot distinguish redaction from a veto;
+    // explicit middleware failure provenance is a separate contract concern.
+    return new PiBashExitError(text, original.exitCode, bashResultOutput(original, text));
+  }
+  return new Error(text.trim() || "Pi bash failed");
+}
+
+/** Only provider-classified exits may cross a runtime bridge as settle metadata. */
+export function piBashExitMetadata(error: unknown): { exitCode: number; output: string } | undefined {
+  return error instanceof PiBashExitError
+    ? { exitCode: error.exitCode, output: error.output }
+    : undefined;
+}

--- a/src/providers/captured-tools-provider.ts
+++ b/src/providers/captured-tools-provider.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { runAbortable, throwIfAborted } from "../async-settlement.js";
 import type { AgentToolResult, SourceInfo } from "@earendil-works/pi-coding-agent";
 import { CapturedToolCatalog, type CapturedToolEntry } from "../capture/catalog.js";
+import { classifyPiBashError, piBashResultError } from "../core/pi-bash-error.js";
 import type {
   FabricActionDescriptor,
   FabricInvocationContext,
@@ -171,6 +172,7 @@ export class CapturedToolsProvider implements FabricProvider {
     let result: AgentToolResult<unknown>;
     let isError = false;
     let thrown: unknown;
+    let executionStarted = false;
     let updateTail: Promise<void> = Promise.resolve();
     try {
       const preflight = await runAbortable(context.signal, () => runner.emitToolCall({
@@ -183,6 +185,7 @@ export class CapturedToolsProvider implements FabricProvider {
       if (preflight?.block) {
         throw new Error(preflight.reason || `Captured tool ${entry.name} was blocked`);
       }
+      executionStarted = true;
       result = await runAbortable(context.signal, () =>
         wrappedTool.execute(toolCallId, args, context.signal, (partialResult) => {
         const progress = textFromContent(partialResult.content).trim();
@@ -201,7 +204,7 @@ export class CapturedToolsProvider implements FabricProvider {
         }),
       );
     } catch (error) {
-      thrown = error;
+      thrown = entry.name === "bash" && executionStarted ? classifyPiBashError(error) : error;
       isError = true;
       result = {
         content: [
@@ -243,6 +246,7 @@ export class CapturedToolsProvider implements FabricProvider {
     }));
 
     if (isError) {
+      if (entry.name === "bash") throw piBashResultError(thrown, textFromContent(result.content));
       const text = textFromContent(result.content).trim();
       throw new Error(
         text || (thrown instanceof Error ? thrown.message : `Captured tool ${entry.name} failed`),

--- a/src/providers/pi-tools-provider.ts
+++ b/src/providers/pi-tools-provider.ts
@@ -14,6 +14,7 @@ import {
 import { runAbortable, throwIfAborted } from "../async-settlement.js";
 import { CapturedToolCatalog } from "../capture/catalog.js";
 import { PI_CORE_TOOL_NAMES, type PiCoreToolName } from "../core/pi-tools.js";
+import { classifyPiBashError, piBashResultError } from "../core/pi-bash-error.js";
 import { expandSkillDirMarkersForRead } from "../core/skill-dir.js";
 import type {
   FabricActionDescriptor,
@@ -295,7 +296,10 @@ export class PiToolsProvider implements FabricProvider {
           (partialResult) => this.#attachPartialPreview(name, partialResult, args, context),
           context.extensionContext,
         ),
-      );
+      ).catch((error) => {
+        throwIfAborted(context.signal);
+        throw name === "bash" ? classifyPiBashError(error) : error;
+      });
       this.#attachReadMedia(name, result, context);
       this.#attachReadNote(name, result, context);
       this.#attachPreview(name, result, args, context);
@@ -329,6 +333,7 @@ export class PiToolsProvider implements FabricProvider {
     let result: PiToolResult;
     let isError = false;
     let thrown: unknown;
+    let executionStarted = false;
     let updateTail: Promise<void> = Promise.resolve();
     try {
       const preflight = await runAbortable(context.signal, () => runner.emitToolCall({
@@ -341,6 +346,7 @@ export class PiToolsProvider implements FabricProvider {
       if (preflight?.block) {
         throw new Error(preflight.reason || `Pi tool ${name} was blocked`);
       }
+      executionStarted = true;
       result = (await runAbortable(context.signal, () => tool.execute(
         toolCallId,
         args,
@@ -362,7 +368,7 @@ export class PiToolsProvider implements FabricProvider {
         context.extensionContext,
       ))) as PiToolResult;
     } catch (error) {
-      thrown = error;
+      thrown = name === "bash" && executionStarted ? classifyPiBashError(error) : error;
       isError = true;
       result = {
         content: [
@@ -412,6 +418,7 @@ export class PiToolsProvider implements FabricProvider {
     }));
 
     if (isError) {
+      if (name === "bash") throw piBashResultError(thrown, textContent(result.content));
       const text = textContent(result.content).trim();
       throw new Error(text || (thrown instanceof Error ? thrown.message : `Pi tool ${name} failed`));
     }

--- a/src/runtime/node-process-child-source.ts
+++ b/src/runtime/node-process-child-source.ts
@@ -97,6 +97,10 @@ process.on("message", (message) => {
   if (!operation) return;
   pending.delete(message.id);
   if (message.ok) operation.resolve(message.value);
-  else operation.reject(new Error(message.error ?? "Host call failed"));
+  else {
+    const error = new Error(message.error ?? "Host call failed");
+    if (message.bashExit) error.__fabricBashExit = message.bashExit;
+    operation.reject(error);
+  }
 });
 `;

--- a/src/runtime/node-process-runtime.ts
+++ b/src/runtime/node-process-runtime.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { runAbortable, settleWithin } from "../async-settlement.js";
+import { piBashExitMetadata } from "../core/pi-bash-error.js";
 import {
   GUEST_SETUP,
   type FabricHostCall,
@@ -164,6 +165,7 @@ export class NodeProcessRuntime {
               id: message.id,
               ok: false,
               error: error instanceof Error ? error.message : String(error),
+              bashExit: message.ref === "pi.bash" ? piBashExitMetadata(error) : undefined,
             }),
         );
         hostTasks.add(task);

--- a/src/runtime/quickjs-runtime.ts
+++ b/src/runtime/quickjs-runtime.ts
@@ -1,6 +1,7 @@
 import releaseSyncVariant from "@jitl/quickjs-singlefile-mjs-release-sync";
 import { newQuickJSWASMModuleFromVariant } from "quickjs-emscripten-core";
 import { runAbortable, settleWithin } from "../async-settlement.js";
+import { piBashExitMetadata } from "../core/pi-bash-error.js";
 import { createGuestStackMap, remapGuestErrorText } from "./guest-stack-map.js";
 import { transpileFabricCodeWithSourceMap } from "./type-checker.js";
 
@@ -390,14 +391,16 @@ globalThis.pi = new Proxy({}, {
         typeof args === "object" && args !== null && args.settle === true;
       const call = __call("pi." + name, __normalizePiArgs(name, args));
       const promise = settle ? call.catch((error) => {
-        const message = error instanceof Error ? error.message : String(error);
-        const match = /(?:^|\\n\\n)Command exited with code (\\d+)$/.exec(message);
-        if (!match) throw error;
+        // node-process bridge errors originate in a different VM realm.
+        const message = typeof error?.message === "string" ? error.message : String(error);
+        const exit = error?.__fabricBashExit;
+        if (!exit || !Number.isSafeInteger(exit.exitCode) || exit.exitCode <= 0 ||
+            typeof exit.output !== "string") throw error;
         return {
           ok: false,
-          output: message.slice(0, match.index),
+          output: exit.output,
           details: null,
-          exitCode: Number(match[1]),
+          exitCode: exit.exitCode,
           error: message,
         };
       }) : call;
@@ -971,6 +974,12 @@ export class QuickJsRuntime {
               const errorHandle = context.newError(
                 error instanceof Error ? error.message : String(error),
               );
+              const exit = reference === "pi.bash" ? piBashExitMetadata(error) : undefined;
+              if (exit) {
+                const metadata = jsonHandle(context, jsonObject, jsonParse, exit);
+                context.setProp(errorHandle, "__fabricBashExit", metadata);
+                metadata.dispose();
+              }
               promise.reject(errorHandle);
               errorHandle.dispose();
             })

--- a/tests/pi-bash-cwd.test.ts
+++ b/tests/pi-bash-cwd.test.ts
@@ -12,12 +12,17 @@ import {
 } from "../src/providers/pi-bash-cwd.js";
 
 const roots: string[] = [];
+const cwdMarker = "fabric-cwd-marker.txt";
 
 const makeTree = (): { root: string; nested: string } => {
   const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "pi-bash-cwd-")));
   roots.push(root);
   const nested = path.join(root, "services", "link");
   fs.mkdirSync(nested, { recursive: true });
+  // Reading a relative file proves the shell reached the target directory
+  // without comparing Git Bash's /tmp spelling with a Windows native path.
+  fs.writeFileSync(path.join(root, cwdMarker), root);
+  fs.writeFileSync(path.join(nested, cwdMarker), nested);
   return { root, nested };
 };
 
@@ -59,19 +64,18 @@ describe("resolvePiBashCwd", () => {
     fs.symlinkSync(nested, link, "dir");
     const result = await new BashCwdDefinitions().get(link).execute(
       "pi-bash-cwd-symlink-test",
-      { command: "pwd" },
+      { command: `cat ${cwdMarker}` },
       undefined,
       () => {},
       undefined as never,
     );
-    const reported = (result.content[0] as { text: string }).text.trim();
-    expect(fs.realpathSync(reported)).toBe(fs.realpathSync(link));
+    expect(result.content[0]).toMatchObject({ text: nested });
   });
 
   it("names the resolved path when the directory is missing", () => {
     const { root } = makeTree();
     expect(() => resolvePiBashCwd(root, "nope")).toThrowError(
-      new RegExp(`Invalid pi\\.bash cwd "nope" \\(${root}/nope\\)`),
+      `Invalid pi.bash cwd "nope" (${path.join(root, "nope")})`,
     );
   });
 
@@ -148,12 +152,12 @@ describe("BashCwdDefinitions", () => {
     const definitions = new BashCwdDefinitions();
     const result = await definitions.get(nested).execute(
       "pi-bash-cwd-test",
-      { command: "pwd" },
+      { command: `cat ${cwdMarker}` },
       undefined,
       () => {},
       undefined as never,
     );
-    expect(result.content[0]).toMatchObject({ text: expect.stringContaining(nested) });
+    expect(result.content[0]).toMatchObject({ text: nested });
   });
 
   // Guards the regression this change exists to prevent: declaring cwd in the
@@ -163,12 +167,11 @@ describe("BashCwdDefinitions", () => {
     const { root, nested } = makeTree();
     const result = await createBashToolDefinition(root).execute(
       "pi-bash-cwd-test",
-      { command: "pwd", cwd: nested } as never,
+      { command: `cat ${cwdMarker}`, cwd: nested } as never,
       undefined,
       () => {},
       undefined as never,
     );
-    expect(result.content[0]).toMatchObject({ text: expect.stringContaining(root) });
-    expect((result.content[0] as { text: string }).text).not.toContain(nested);
+    expect(result.content[0]).toMatchObject({ text: root });
   });
 });

--- a/tests/pi-bash-error.test.ts
+++ b/tests/pi-bash-error.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { classifyPiBashError, piBashExitMetadata, piBashResultError } from "../src/core/pi-bash-error.js";
+import { QuickJsRuntime } from "../src/runtime/quickjs-runtime.js";
+import { NodeProcessRuntime } from "../src/runtime/node-process-runtime.js";
+
+describe("native bash exit classification", () => {
+  it.each([
+    "Command timed out after 1 seconds",
+    "Command aborted",
+    "spawn ENOENT",
+    "Command exited with code 0",
+    "Command exited with code -1",
+    "Command exited with code 999999999999999999999",
+    "Command exited with code 7\nannotation",
+  ])("does not classify %s as a native exit", (message) => {
+    const error = new Error(message);
+    expect(classifyPiBashError(error)).toBe(error);
+    expect(piBashExitMetadata(error)).toBeUndefined();
+  });
+
+  it("keeps stdout whitespace and an earlier fake exit marker", () => {
+    const output = "  leading\n\nCommand exited with code 9\n";
+    const error = classifyPiBashError(new Error(output + "\n\nCommand exited with code 7"));
+    expect(piBashExitMetadata(error)).toEqual({ exitCode: 7, output });
+  });
+
+  it("handles an empty native output", () => {
+    expect(piBashExitMetadata(classifyPiBashError(new Error("Command exited with code 7"))))
+      .toEqual({ exitCode: 7, output: "" });
+  });
+
+  it("does not infer an exit from the final display text", () => {
+    const error = piBashResultError(new Error("policy denied"), "Command exited with code 7");
+    expect(piBashExitMetadata(error)).toBeUndefined();
+  });
+
+  it("uses the native exit code even when annotations contain another marker", () => {
+    const original = new Error("out\n\nCommand exited with code 7");
+    const error = piBashResultError(classifyPiBashError(original), original.message + "\n\nCommand exited with code 9");
+    expect(piBashExitMetadata(error)).toEqual({ exitCode: 7, output: "out\n\nCommand exited with code 9" });
+  });
+
+  it.each([
+    ["trim", "partial\n\nCommand exited with code 7", "partial"],
+    ["line endings", "  partial\r\n\r\nCommand exited with code 7", "  partial"],
+    ["redaction", "[redacted]\n\nCommand exited with code 7", "[redacted]"],
+    ["replacement", "[output withheld]", "[output withheld]"],
+    ["empty replacement", "", ""],
+  ])("retains exit status using only the %s display text", (_name, text, output) => {
+    const original = classifyPiBashError(new Error("  partial\n\nCommand exited with code 7"));
+    const result = piBashResultError(original, text);
+    expect(result.message).toBe(text);
+    expect(piBashExitMetadata(result)).toEqual({ exitCode: 7, output });
+  });
+
+  it("keeps ambiguous status-looking output after redaction", () => {
+    const original = classifyPiBashError(new Error("private-value\n\nCommand exited with code 7"));
+    const text = "[redacted]\n\nCommand exited with code 7\n\nCommand exited with code 7";
+    expect(piBashExitMetadata(piBashResultError(original, text))).toEqual({ exitCode: 7, output: text });
+  });
+
+  it("never restores a cleared unclassified error message", () => {
+    const result = piBashResultError(new Error("private-value"), "");
+    expect(result.message).not.toContain("private-value");
+    expect(piBashExitMetadata(result)).toBeUndefined();
+  });
+});
+
+describe.each([QuickJsRuntime, NodeProcessRuntime])("settle metadata bridge %s", (Runtime) => {
+  it.each(["spawn ENOENT", "Command timed out after 1 seconds", "policy denied\n\nCommand exited with code 7"])("rejects an unclassified host error: %s", async (message) => {
+    const result = await new Runtime().execute(
+      "return await pi.bash('false', {settle: true});",
+      async () => { throw Object.assign(new Error(message), { __fabricBashExit: { exitCode: 7, output: "fake" } }); },
+      { timeoutMs: 5000, memoryLimitBytes: 32 * 1024 * 1024 },
+    );
+    expect(result.terminationReason).toBe("runtime_error");
+    expect(result.error).toContain(message.split("\n")[0]);
+  });
+});

--- a/tests/pi-bash-settle.test.ts
+++ b/tests/pi-bash-settle.test.ts
@@ -1,0 +1,195 @@
+import {
+  createBashToolDefinition,
+  createSyntheticSourceInfo,
+  ExtensionRunner,
+  type ExtensionContext,
+  type RegisteredTool,
+} from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { CapturedToolCatalog } from "../src/capture/catalog.js";
+import { DEFAULT_FABRIC_CONFIG } from "../src/config.js";
+import { ActionRegistry } from "../src/core/action-registry.js";
+import { FabricExecutionService } from "../src/execution-service.js";
+import { PiToolsProvider } from "../src/providers/pi-tools-provider.js";
+import { CapturedToolsProvider } from "../src/providers/captured-tools-provider.js";
+
+type Patch = "none" | "prefix" | "suffix" | "replace" | "deny" | "recover";
+type ResultEvent = Parameters<ExtensionRunner["emitToolResult"]>[0];
+type ResultPatch = Awaited<ReturnType<ExtensionRunner["emitToolResult"]>>;
+const annotation = "✓ middleware annotation";
+const command = "printf 'probe-output\\n'; exit 7";
+const cwd = process.cwd();
+
+async function run(
+  runtime: "quickjs" | "node-process",
+  patch: Patch,
+  options: { command?: string; captured?: boolean; preflight?: boolean; noRunner?: boolean; settle?: boolean; timeout?: number; signal?: AbortSignal; approvalDenied?: boolean; middleware?: (event: ResultEvent) => ResultPatch } = {},
+) {
+  const runner = {
+    createContext: () => ({ cwd, sessionManager: { getSessionId: () => "settle-regression", getSessionFile: () => undefined } }),
+    getActiveTools: () => [],
+    emit: async () => undefined,
+    emitToolCall: async () => options.preflight
+      ? { block: true, reason: "policy denied\n\nCommand exited with code 7" }
+      : undefined,
+    emitToolResult: async (event: { content: { type: string; text?: string }[]; isError: boolean }) => {
+      const note = { type: "text", text: annotation };
+      // Real ExtensionRunner returns the effective isError even for content-only patches.
+      if (patch === "prefix") return { content: [note, ...event.content], isError: event.isError };
+      if (patch === "suffix") return { content: [...event.content, note], isError: event.isError };
+      if (patch === "replace" || patch === "deny") return {
+        content: [{ type: "text", text: "policy denied\n\nCommand exited with code 9" }], isError: true,
+      };
+      if (patch === "recover") return { content: [note], isError: false };
+      return undefined;
+    },
+  } as unknown as ExtensionRunner;
+  if (options.middleware) {
+    // Exercise Pi's real merge semantics: even a content-only handler returns
+    // the inherited isError, not a signal that the handler added a new failure.
+    const handler = options.middleware;
+    const middlewareRunner = {
+      createContext: () => runner.createContext(),
+      extensions: [{
+        path: "/extensions/settle-test/index.ts",
+        handlers: new Map([["tool_result", [handler]]]),
+      }],
+    } as unknown as ExtensionRunner;
+    runner.emitToolResult = (event) => ExtensionRunner.prototype.emitToolResult.call(middlewareRunner, event);
+  }
+  const catalog = new CapturedToolCatalog();
+  catalog.replace(options.captured ? [{
+    definition: createBashToolDefinition(cwd) as RegisteredTool["definition"],
+    sourceInfo: createSyntheticSourceInfo("/extensions/bash-override/index.ts", { source: "test" }),
+  }] : [], runner, DEFAULT_FABRIC_CONFIG.capture, "/extensions/pi-fabric/index.ts");
+  const registry = new ActionRegistry();
+  registry.register(new PiToolsProvider(cwd, options.noRunner ? undefined : catalog, new CapturedToolsProvider(catalog)));
+  const config = structuredClone(DEFAULT_FABRIC_CONFIG);
+  config.executor.runtime = runtime;
+  config.approvals.execute = options.approvalDenied ? "deny" : "allow";
+  return new FabricExecutionService(registry, config).execute({
+    code: "return await pi.bash({command: π.command, settle: π.settle === 'true', ...(π.timeout ? {timeout: Number(π.timeout)} : {})});",
+    strings: { command: options.command ?? command, settle: String(options.settle ?? true), timeout: options.timeout === undefined ? "" : String(options.timeout) },
+    signal: options.signal,
+    parentToolCallId: "settle-regression",
+    context: {
+      cwd, hasUI: false,
+      sessionManager: { getSessionId: () => "settle-regression", getSessionFile: () => undefined },
+    } as unknown as ExtensionContext,
+    onPartial() {},
+  });
+}
+
+describe.each(["quickjs", "node-process"] as const)("pi.bash settle via %s", (runtime) => {
+  it.each(["none", "prefix", "suffix"] as const)("settles native exit with %s middleware", async (patch) => {
+    const result = await run(runtime, patch);
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(result.value).toMatchObject({ ok: false, exitCode: 7, details: null });
+    const value = result.value as { output: string; error: string };
+    expect(value.output).toContain("probe-output\n");
+    expect(value.output).not.toContain("Command exited with code 7");
+    if (patch !== "none") {
+      expect(value.output).toContain(annotation);
+      expect(value.error).toContain(annotation);
+    } else expect(value.output).toBe("probe-output\n");
+  });
+
+  it("settles a captured bash override with suffix middleware", async () => {
+    const result = await run(runtime, "suffix", { captured: true });
+    expect(result.error).toBeUndefined();
+    expect(result.value).toMatchObject({ ok: false, exitCode: 7 });
+  });
+
+  describe.each([false, true])("processed results (captured=%s)", (captured) => {
+    it.each([
+      ["trim", (text: string): string => text.trim(), "private-value\n"],
+      ["split and prefix", (text: string): string => "annotation\n" + text.trim(), "annotation\nprivate-value\n"],
+      ["line endings", (text: string): string => text.replaceAll("\n", "\r\n"), "  private-value\r\n"],
+      ["redaction", (text: string): string => text.replaceAll("private-value", "[redacted]"), "  [redacted]\n"],
+      ["replacement", (_text: string): string => "[output withheld]", "[output withheld]"],
+      ["empty replacement", (_text: string): string => "", ""],
+    ] as const)("settles after %s without restoring original content", async (_name, transform, output) => {
+      const result = await run(runtime, "none", {
+        captured,
+        command: "printf '  private-value\\n'; exit 7",
+        middleware: (event: ResultEvent): ResultPatch => ({
+          content: transform(event.content.filter((part) => part.type === "text").map((part) => part.text).join("\n"))
+            .split("\n").map((text) => ({ type: "text" as const, text })),
+        }),
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.value).toMatchObject({ ok: false, exitCode: 7, output });
+      if (!output.includes("private-value")) {
+        expect(JSON.stringify(result.value)).not.toContain("private-value");
+      }
+    });
+  });
+
+  it("settles without an extension runner", async () => {
+    expect((await run(runtime, "none", { noRunner: true })).value)
+      .toMatchObject({ ok: false, exitCode: 7, output: "probe-output\n" });
+  });
+
+  it("still rejects without settle", async () => {
+    const result = await run(runtime, "suffix", { settle: false });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(annotation);
+  });
+
+  it("does not classify successful stdout as an exit failure", async () => {
+    const result = await run(runtime, "suffix", { command: "printf 'Command exited with code 7'" });
+    expect(result.value).toMatchObject({ ok: true });
+  });
+
+  it.each([false, true])("does not settle preflight denial (captured=%s)", async (captured) => {
+    const result = await run(runtime, "suffix", { preflight: true, captured });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("policy denied");
+  });
+
+  it("does not settle a middleware failure after native success", async () => {
+    const result = await run(runtime, "deny", { command: "true" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("policy denied");
+  });
+
+  it("does not replace the native exit code with one from middleware text", async () => {
+    // Known interface limitation: after a native failure, replacement text
+    // plus effective isError:true cannot identify a new middleware veto.
+    const result = await run(runtime, "replace");
+    expect(result.success).toBe(true);
+    expect(result.value).toMatchObject({
+      ok: false, exitCode: 7, output: "policy denied\n\nCommand exited with code 9",
+    });
+  });
+
+  it("honors explicit middleware recovery", async () => {
+    const result = await run(runtime, "recover");
+    expect(result.value).toMatchObject({ ok: true, output: annotation });
+  });
+
+  it("does not settle approval denial", async () => {
+    expect((await run(runtime, "none", { approvalDenied: true })).success).toBe(false);
+  });
+
+  it("does not settle a timeout even with an exit marker in stdout", async () => {
+    const result = await run(runtime, "suffix", {
+      command: "printf 'Command exited with code 7'; sleep 3", timeout: 1,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Command timed out");
+  });
+
+  it("does not settle cancellation", async () => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(new Error("user cancelled\n\nCommand exited with code 7")), 200);
+    try {
+      const result = await run(runtime, "suffix", { command: "sleep 3", signal: controller.signal });
+      expect(result.success).toBe(false);
+      expect(result.trace.outcome).toBe("aborted");
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+});

--- a/tests/pi-shorthand.test.ts
+++ b/tests/pi-shorthand.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { GUEST_TYPE_DECLARATIONS } from "../src/runtime/guest-types.js";
 import { typeCheckFabricCode } from "../src/runtime/type-checker.js";
 import { QuickJsRuntime } from "../src/runtime/quickjs-runtime.js";
+import { classifyPiBashError } from "../src/core/pi-bash-error.js";
 
 const options = { timeoutMs: 5_000, memoryLimitBytes: 32 * 1024 * 1024 };
 
@@ -55,7 +56,7 @@ describe("pi bare-string shorthand", () => {
 
     const hostCall = vi.fn(async (_ref: string, args: Record<string, unknown>) => {
       if (args.command === "exit 7") {
-        throw new Error("before\n\n\nCommand exited with code 7");
+        throw classifyPiBashError(new Error("before\n\n\nCommand exited with code 7"));
       }
       throw new Error("Command timed out after 1000ms");
     });
@@ -341,7 +342,7 @@ describe("pi positional args", () => {
 
   it("settles a two-arg bash call when the merged options carry settle:true", async () => {
     const hostCall = vi.fn(async (_ref: string, _args: Record<string, unknown>): Promise<never> => {
-      throw new Error("oops\n\n\nCommand exited with code 7");
+      throw classifyPiBashError(new Error("oops\n\n\nCommand exited with code 7"));
     });
     const result = await new QuickJsRuntime().execute(
       'return await pi.bash("exit 7", { settle: true });',

--- a/tests/quickjs-runtime.test.ts
+++ b/tests/quickjs-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { QuickJsRuntime } from "../src/runtime/quickjs-runtime.js";
+import { classifyPiBashError } from "../src/core/pi-bash-error.js";
 import { transpileFabricCodeWithSourceMap } from "../src/runtime/type-checker.js";
 
 const options = {
@@ -1058,7 +1059,7 @@ return "never";
 
   it("guards settled bash envelopes and still exposes ok/exitCode/output reads", async () => {
     const hostCall = vi.fn(async () => {
-      throw new Error("sync-spawn\n\nCommand exited with code 3");
+      throw classifyPiBashError(new Error("sync-spawn\n\nCommand exited with code 3"));
     });
     const reads = await new QuickJsRuntime().execute(
       `
@@ -1155,4 +1156,3 @@ describe("QuickJsRuntime guest stack remapping", () => {
     expect(result.error).toContain("pi-fabric-guest.js");
   });
 });
-


### PR DESCRIPTION
## Problem

`pi.bash(..., { settle: true })` recognizes a nonzero exit by matching the end of the final error text. `tool_result` middleware can append a harmless annotation, so an ordinary exit unexpectedly rejects the whole `fabric_exec` call. The same failure occurs with native `code` calls; no script-sugar feature is needed.

Related background: #8. This PR is based on upstream `3393b74` and contains only the shared settle fix, tests, and contract documentation. It does not include the local script-sugar feature.

## Fix

- Classify a native bash exception at the execute stage, before result middleware, and preserve the exit status through both the QuickJS and Node-process bridges.
- Keep the default throwing behavior unless `settle: true` is requested. Native bash and captured bash overrides use the same classification helper.
- Treat final text as presentation: trimming, splitting text blocks, newline changes, redaction, replacement, and clearing cannot erase the native exit code. Return only middleware-processed text, without restoring removed content. Remove the native status line only when its location is unambiguous.
- Keep timeout, cancellation, approval/preflight failures, and middleware failures after a successful command rejecting. Preserve explicit middleware recovery (`isError: false`).

## Known semantic limit

After a native nonzero exit, Pi returns only the effective `isError`; it does not identify a new failure introduced by a result handler. A handler that appends **or replaces** text to express an additional policy failure is indistinguishable from annotation/redaction. This PR preserves the native exit classification in that case; it does **not** claim to enforce such an unmarked post-execution veto. Callers relying on every final error throwing should omit `settle`.

The separate interface question is tracked in earendil-works/pi#8856. No new mandatory plugin protocol is introduced here.

## Dogfood evidence (before the fix)

Window: **2026-08-28 18:57:56 to 2026-08-30 18:57:56, Asia/Shanghai (UTC+8)**. Assistant tool calls were selected by message timestamp, paired by call ID, and deduplicated across fork/export copies; failed attempts were retained. Only aggregate counts are published, not session files, business commands, or raw output.

| Observation | Count |
| --- | ---: |
| Distinct `fabric_exec` calls | 3,661 |
| Calls through the local script overlay, which invokes `pi.bash` | 616 |
| Overlay calls explicitly requesting `settle: true` | 374 |
| Those settle calls still returning an outer error with a nonzero-exit marker | 25 |
| Of those 25: recognizable Lens annotations / appended timing marker | 24 / 1 |

The records span local builds without reliable per-process build attestation. These are compatibility signals, not task-success statistics or proof that every historical failure had the same cause. The script overlay was the discovery surface, not a dependency of this fix.

## Controlled acceptance

The harmless command `printf 'probe-output\n'; exit 7` isolated the behavior without replaying business scripts or calling a model:

| Middleware decoration | Before | After |
| --- | --- | --- |
| None | settled, exit 7 | settled, exit 7 |
| Prefix annotation | settled, exit 7 | settled, exit 7 |
| Suffix annotation | unexpected outer error | settled, exit 7 |

On the local dogfood branch, equivalent script/code probes changed from **4/6 to 6/6 passing**, and the final stacked build passed **2,233 tests**. Additional probes using the real Pi bash tool, real `ExtensionRunner.emitToolResult`, and compiled QuickJS verified trimming, redaction, and cleared output. There is no matched post-fix real-world dogfood window yet, and no speedup claim.

The standalone PR branch has its own source/provider/runtime regression coverage, including both runtimes, captured overrides, middleware transformations, spoofed exit text, opt-in behavior, timeouts, cancellation, approval/preflight rejection, and the documented middleware limitation.

Exact standalone-branch validation (Pi 0.84.4, Node 24, macOS):

- `pnpm run check`: **160 test files / 2,186 tests passed**, including type checking, build-artifact/lazy-graph checks, and dead-code lint.
- Compiled QuickJS + real bash + real Pi result middleware: **4/4** probes passed (suffix annotation, trim, redaction, cleared output).
- `git diff --check`: clean. No new dependencies or script-sugar files.

These are local results. GitHub's Ubuntu/Windows checks are separate and are not claimed to have passed here.

AI assistance: implemented and validated with Codex; submitted at the user's request.
