### PR TITLE
fix(agents): route durable actor creates through the resident host when the registry is already owned

### DIFF
--- a/src/actors/manager.ts
+++ b/src/actors/manager.ts
@@ -372,9 +372,21 @@ export class ActorManager {
     });
   }
 
-  async create(request: FabricActorRequest): Promise<FabricActorInfo> {
+  /**
+   * Create an actor. The asRegistryOwner option is reserved for the resident
+   * host control channel (residency file protocol): that host already IS the
+   * authoritative registry owner, so the foreign-live-actor guard - which
+   * protects against concurrent local starters - must not veto creates that
+   * arrive over that channel (e.g. while a ceded-but-not-yet-adopted durable
+   * still carries its creating root lineage).
+   */
+  async create(
+    request: FabricActorRequest,
+    { asRegistryOwner = false }: { asRegistryOwner?: boolean } = {},
+  ): Promise<FabricActorInfo> {
     this.#refreshOwnership();
     if (
+      !asRegistryOwner &&
       [...this.#actors.values()].some(
         (actor) => actor.status !== "stopped" && !this.#canManage(actor.id),
       )

--- a/src/providers/agents-provider.ts
+++ b/src/providers/agents-provider.ts
@@ -1094,9 +1094,32 @@ export class AgentsProvider implements FabricProvider {
           context.activity?.({ type: "entity", id: actor.id, kind: "actor", name: actor.name });
           return actor;
         }
-        if (request.residency === "durable") await this.#resident().ensureHost();
+        if (request.residency === "durable") {
+          await this.#resident().ensureHost();
+          let actor: Awaited<ReturnType<ActorManager["create"]>>;
+          try {
+            actor = await this.actorManager.create(request);
+            if (actor.residency === "durable") await this.#activateDurableActor(actor);
+          } catch (error) {
+            if (
+              !(error instanceof Error) ||
+              !error.message.includes("registry is owned by another host")
+            ) {
+              throw error;
+            }
+            // The registry already transferred to the resident host (a prior
+            // durable was created and ceded to it). Route the authoritative
+            // create over the residency file protocol instead of failing:
+            // the resident host creates it as the registry owner.
+            const config = this.#resident().options.config;
+            const client = new ResidentActorClient(config.meshRoot, config.rootId);
+            actor = await client.createActor(request);
+          }
+          this.participants.scheduleRefresh();
+          context.activity?.({ type: "entity", id: actor.id, kind: "actor", name: actor.name });
+          return actor;
+        }
         const actor = await this.actorManager.create(request);
-        if (actor.residency === "durable") await this.#activateDurableActor(actor);
         this.participants.scheduleRefresh();
         context.activity?.({ type: "entity", id: actor.id, kind: "actor", name: actor.name });
         return actor;

--- a/src/residency/host.ts
+++ b/src/residency/host.ts
@@ -608,7 +608,7 @@ class ResidentHost {
         // This handler already runs inside the authoritative durable host.
         // Keep the new actor locally owned; ceding it here created a needless
         // self-transfer window that blocked the next recruitment request.
-        const actor = await this.actors.create(command.request);
+        const actor = await this.actors.create(command.request, { asRegistryOwner: true });
         response = {
           format: RESIDENT_HOST_FORMAT,
           requestId,

--- a/tests/actor-manager.test.ts
+++ b/tests/actor-manager.test.ts
@@ -511,6 +511,50 @@ describe("ActorManager", () => {
     ).rejects.toThrow("registry is owned by another host");
   });
 
+  it("creates via the registry-owner channel while a live foreign actor holds the registry", async () => {
+    const state = setup(true);
+    const actor = await state.actors.create({
+      name: "foreign-live-owner-channel",
+      instructions: "Owned elsewhere.",
+      residency: "session",
+    });
+    const peerIdentity: MeshIdentity = {
+      id: "session:owner-channel",
+      name: "main",
+      kind: "main",
+      sessionId: "owner-channel",
+    };
+    const peer = new ActorManager(
+      "owner-channel",
+      peerIdentity,
+      state.mesh,
+      state.meshConfig,
+      state.agents,
+      () => {},
+      {
+        actorRoot: path.join(state.root, "actors"),
+        persistent: true,
+        claimResidency: "session",
+        rootId: peerIdentity.id,
+        // Live foreign owner advertised by the participant directory.
+        canManageActor: () => false,
+      },
+    );
+    actorManagers.push(peer);
+
+    // Plain callers stay guarded.
+    await expect(
+      peer.create({ name: "blocked", instructions: "Guard stays for plain callers." }),
+    ).rejects.toThrow("registry is owned by another host");
+    // The resident host control channel creates as the registry owner.
+    const created = await peer.create(
+      { name: "via-owner-channel", instructions: "Created as the registry owner." },
+      { asRegistryOwner: true },
+    );
+    expect(created.name).toBe("via-owner-channel");
+    expect(created.id).toBeTruthy();
+  });
+
   it("settles exactly one adopter when concurrent starters race an orphan", async () => {
     const state = setup(true);
     const actor = await state.actors.create({

--- a/tests/agents-provider.test.ts
+++ b/tests/agents-provider.test.ts
@@ -25,6 +25,8 @@ import type {
 import type { FabricInvocationContext } from "../src/protocol.js";
 import { FabricControlPlane } from "../src/topology/control-plane.js";
 import { AgentsProvider, collectAgentToolPreviewNodes } from "../src/providers/agents-provider.js";
+import { RESIDENT_HOST_FORMAT, residentRoot } from "../src/residency/protocol.js";
+import type { ResidencyClient } from "../src/residency/client.js";
 import { snapshotHandoffSession } from "../src/agents/handoff.js";
 import { AgentManager } from "../src/agents/manager.js";
 import type { AgentRunRecord } from "../src/agents/types.js";
@@ -169,7 +171,20 @@ const setup = (
     undefined,
     () => options?.modelsConfig ?? DEFAULT_FABRIC_CONFIG.models,
   );
-  return { root, actors, agents, globalActors, provider, mainDeliveries };
+  return {
+    root,
+    mesh,
+    identity,
+    mainAgent,
+    participants,
+    control,
+    lifecycle,
+    actors,
+    agents,
+    globalActors,
+    provider,
+    mainDeliveries,
+  };
 };
 
 afterEach(async () => {
@@ -357,6 +372,119 @@ describe("AgentsProvider runner support", () => {
       ),
     ).rejects.toThrow("trusted project");
     expect(actors.list()).toEqual([]);
+  });
+
+  it("routes a durable create through the resident host when the local registry is already owned", async () => {
+    const state = setup();
+    const rootId = state.identity.id;
+    const meshRoot = state.mesh.root;
+    // Simulate the transferred registry: a live foreign actor over the shared
+    // registry makes the local manager's create guard throw.
+    const peerIdentity: MeshIdentity = {
+      id: "session:foreign-owner",
+      name: "main",
+      kind: "main",
+      sessionId: "foreign-owner",
+    };
+    const peer = new ActorManager(
+      "foreign-owner",
+      peerIdentity,
+      state.mesh,
+      { ...DEFAULT_FABRIC_CONFIG.mesh, actorPollMs: 20 },
+      state.agents,
+      () => {},
+      {
+        actorRoot: path.join(state.root, "actors"),
+        persistent: true,
+        claimResidency: "session",
+        rootId: peerIdentity.id,
+      },
+    );
+    actorManagers.push(peer);
+    const foreign = await peer.create({
+      name: "first-durable",
+      instructions: "Ceded to the resident host.",
+      residency: "durable",
+    });
+    // A manager that sees every live actor as owned by another host, like
+    // Main after the registry transferred to the resident host.
+    const guardedActors = new ActorManager(
+      "guarded-main",
+      state.identity,
+      state.mesh,
+      { ...DEFAULT_FABRIC_CONFIG.mesh, actorPollMs: 20 },
+      state.agents,
+      () => {},
+      {
+        actorRoot: path.join(state.root, "actors"),
+        persistent: true,
+        claimResidency: "session",
+        rootId: state.identity.id,
+        canManageActor: () => false,
+      },
+    );
+    actorManagers.push(guardedActors);
+    await waitFor(() => guardedActors.list().some((entry) => entry.id === foreign.id));
+
+    // Fake resident host over the real file protocol.
+    const hostDir = residentRoot(meshRoot, rootId);
+    fs.mkdirSync(path.join(hostDir, "responses"), { recursive: true });
+    fs.writeFileSync(path.join(hostDir, "owner.json"), JSON.stringify({ pid: process.pid }));
+    const seen: Array<{ operation?: string; requestId: string }> = [];
+    const poller = setInterval(() => {
+      for (const file of fs.readdirSync(path.join(hostDir, "requests"))) {
+        if (!file.endsWith(".json")) continue;
+        const command = JSON.parse(
+          fs.readFileSync(path.join(hostDir, "requests", file), "utf8"),
+        ) as { operation?: string; requestId: string };
+        if (seen.some((item) => item.requestId === command.requestId)) continue;
+        seen.push(command);
+        fs.writeFileSync(
+          path.join(hostDir, "responses", file),
+          JSON.stringify({
+            format: RESIDENT_HOST_FORMAT,
+            requestId: command.requestId,
+            ok: true,
+            actor: { id: "resident-actor-1", name: "second-durable", status: "idle" },
+            completedAt: Date.now(),
+          }),
+        );
+      }
+    }, 25);
+
+    const residency = {
+      ensureHost: async () => {},
+      options: { config: { meshRoot, rootId } },
+    } as unknown as ResidencyClient;
+    const provider = new AgentsProvider(
+      state.agents,
+      guardedActors,
+      state.globalActors,
+      state.mainAgent,
+      state.participants,
+      state.control,
+      state.lifecycle,
+      undefined,
+      residency,
+      undefined,
+      () => DEFAULT_FABRIC_CONFIG.models,
+    );
+
+    try {
+      const actor = (await provider.invoke(
+        "create",
+        { name: "second-durable", instructions: "Created via the resident host.", residency: "durable" },
+        context,
+      )) as { id: string; name: string };
+      expect(actor.id).toBe("resident-actor-1");
+      expect(actor.name).toBe("second-durable");
+      expect(seen).toHaveLength(1);
+      expect(seen[0]?.operation).toBe("createActor");
+    } finally {
+      clearInterval(poller);
+      fs.rmSync(path.join(hostDir, "requests"), { recursive: true, force: true });
+      fs.rmSync(path.join(hostDir, "responses"), { recursive: true, force: true });
+    }
   });
   it("lists live peer sessions separately from Main", async () => {
     const peer: FabricPeerInfo = {


### PR DESCRIPTION
Fixes the "multiple durable actors" half of #23.

## Problem

After the first `agents.create({ residency: "durable" })` transfers the actor registry to the resident host, every further `agents.create` from Main fails with `Fabric actor registry is owned by another host` — including session-scoped creates. Reproduced on 0.72.0 and 0.78.0 (details in [#23 (comment)](https://github.com/monotykamary/pi-fabric/issues/23#issuecomment-5529206183)).

Additionally, the resident host's own `createActor` handler tripped the same guard whenever a ceded-but-not-yet-adopted durable still carried the creating root's lineage, so the documented "create from inside the owner" workaround could not succeed either.

## Change

- `ActorManager.create` gains an `asRegistryOwner` option reserved for the resident host control channel: it bypasses the foreign-live-actor guard (which protects against concurrent *local* starters) while keeping every plain caller guarded.
- The resident host `createActor` handler now creates as the registry owner.
- `AgentsProvider` durable-create falls back to `ResidentActorClient` (the existing residency file protocol) when the local create hits the ownership guard, so a second durable routes to the authoritative host instead of failing.

Plain callers, the orphan-adoption window, and both pinned create-guard tests (including "Main stays create-guarded") are unchanged.

## Tests

- `actor-manager.test.ts`: owner-channel create succeeds while a live foreign actor holds the registry; plain create from the same manager still throws.
- `agents-provider.test.ts`: with a guarded local manager, a durable create routes through a (fake) resident host over the real file protocol and returns its actor.

`bun run typecheck` and `bun run build` pass. Full suite on Windows: the 12 failing tests there are pre-existing platform failures (symlink EPERM et al.) — verified identical on a clean tree via `git stash`.

Open design question from #23 that this PR deliberately does **not** change: creating a *session-scoped* actor from Main while a resident host owns durable actors is still guarded. Relaxing that touches the pinned adoption-window semantics, so it deserves its own discussion.