### PR TITLE
fix(build): keep lazy imports stable across updates

### DIFF
--- a/scripts/assert-build-artifacts.mjs
+++ b/scripts/assert-build-artifacts.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 
@@ -20,10 +20,30 @@ const stable = [
   "memory/normalize.js",
   "providers/memory-provider.js",
 ];
-const declarations = stable.map((file) => file.replace(/\.js$/, ".d.ts"));
+const lazy = [
+  "agents/claude-cli.js",
+  "agents/compact-control.js",
+  "agents/veda-cli.js",
+  "fabric-runtime-state.js",
+  "runtime/core-override-guest-types.js",
+  "runtime/dynamic-guest-types.js",
+  "runtime/guest-types.js",
+  "runtime/node-process-runtime.js",
+  "runtime/quickjs-runtime.js",
+  "runtime/type-checker.js",
+  "speculation/scanner.js",
+  "ui/dashboard.js",
+  "ui/model-picker.js",
+  "ui/settings.js",
+  "worker/options.js",
+  "worker/run-record.js",
+  "worker/session-export.js",
+];
+const entries = [...stable, ...lazy];
+const declarations = entries.map((file) => file.replace(/\.js$/, ".d.ts"));
 const required = [
-  ...stable,
-  ...stable.map((file) => `${file}.map`),
+  ...entries,
+  ...entries.map((file) => `${file}.map`),
   ...declarations,
   ...declarations.map((file) => `${file}.map`),
 ];
@@ -42,30 +62,40 @@ for (const chunk of chunkFiles) {
 }
 
 const staticImport = /(?:import|export)\s+(?:[^"'()]*?\s+from\s+)?["']([^"']+)["']/g;
-const visited = new Set();
-const stack = [join(dist, "index.js")];
-while (stack.length > 0) {
-  const file = stack.pop();
-  if (!file || visited.has(file)) continue;
-  visited.add(file);
-  const source = readFileSync(file, "utf8");
-  for (const match of source.matchAll(staticImport)) {
-    const specifier = match[1];
-    if (specifier?.startsWith(".")) stack.push(resolve(dirname(file), specifier));
+const staticClosure = (roots) => {
+  const visited = new Set();
+  const stack = [...roots];
+  while (stack.length > 0) {
+    const file = stack.pop();
+    if (!file || visited.has(file)) continue;
+    visited.add(file);
+    const source = readFileSync(file, "utf8");
+    for (const match of source.matchAll(staticImport)) {
+      const specifier = match[1];
+      if (specifier?.startsWith(".")) stack.push(resolve(dirname(file), specifier));
+    }
   }
-}
-const initialSource = [...visited].map((file) => readFileSync(file, "utf8")).join("\n");
+  return visited;
+};
+
+const startupFiles = staticClosure([join(dist, "index.js")]);
+const initialSource = [...startupFiles]
+  .map((file) => readFileSync(file, "utf8"))
+  .join("\n");
 for (const forbidden of ["src/fabric-runtime-state.ts", "src/ui/settings.ts", 'from "mcporter"']) {
   if (initialSource.includes(forbidden)) {
     throw new Error(`Startup static graph contains lazy module marker: ${forbidden}`);
   }
 }
-const allChunks = chunkFiles.map((file) => readFileSync(join(chunks, file), "utf8")).join("\n");
+const lazyFiles = staticClosure(lazy.map((file) => join(dist, file)));
+const lazySource = [...lazyFiles].map((file) => readFileSync(file, "utf8")).join("\n");
 for (const expected of ["src/fabric-runtime-state.ts", "src/ui/settings.ts", 'import("mcporter")']) {
-  if (!allChunks.includes(expected)) throw new Error(`Expected lazy chunk marker not found: ${expected}`);
+  if (!lazySource.includes(expected)) {
+    throw new Error(`Expected lazy entry marker not found: ${expected}`);
+  }
 }
 
-for (const file of stable) {
+for (const file of entries) {
   const checked = spawnSync(process.execPath, ["--check", join(dist, file)], { encoding: "utf8" });
   if (checked.status !== 0) throw new Error(checked.stderr || `Syntax check failed: ${file}`);
 }
@@ -74,4 +104,6 @@ await Promise.all(
     import(new URL(`../dist/${file}`, import.meta.url)),
   ),
 );
-console.log(`build artifacts and lazy startup graph verified (${visited.size} startup files, ${chunkFiles.length} chunks)`);
+console.log(
+  `build artifacts and lazy startup graph verified (${startupFiles.size} startup files, ${lazy.length} stable lazy entries, ${chunkFiles.length} chunks)`,
+);

--- a/scripts/assert-lazy-graph-host-free.mjs
+++ b/scripts/assert-lazy-graph-host-free.mjs
@@ -1,18 +1,18 @@
 #!/usr/bin/env node
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const dist = join(root, "dist");
-const chunks = join(dist, "chunks");
 const hostPackage = "@earendil-works/pi-coding-agent";
-const entries = existsSync(chunks)
-  ? readdirSync(chunks)
-      .filter((file) => /^(dashboard|model-picker)-.*\.js$/.test(file))
-      .map((file) => join(chunks, file))
-  : [];
-if (entries.length === 0) throw new Error("Lazy dashboard chunks were not built");
+const entries = ["ui/dashboard.js", "ui/model-picker.js", "ui/settings.js"].map((file) =>
+  join(dist, file),
+);
+const missing = entries.filter((file) => !existsSync(file));
+if (missing.length > 0) {
+  throw new Error(`Lazy UI entries were not built:\n${missing.join("\n")}`);
+}
 
 const importRe = /(?:import|export)\s+(?:[^"'()]*?\s+from\s+)?["']([^"']+)["']/g;
 const visited = new Set();
@@ -33,7 +33,7 @@ const offenders = [...visited].filter((file) => {
 });
 if (offenders.length > 0) {
   throw new Error(
-    `Lazy dashboard graph must not import ${hostPackage}:\n${offenders.join("\n")}`,
+    `Lazy UI graph must not import ${hostPackage}:\n${offenders.join("\n")}`,
   );
 }
-console.log(`lazy dashboard graph is host-package-free (${visited.size} files checked)`);
+console.log(`lazy UI graph is host-package-free (${visited.size} files checked)`);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,24 +1,49 @@
 #!/usr/bin/env node
 import { build } from "esbuild";
 
+const primaryEntryPoints = [
+  "src/index.ts",
+  "src/protocol.ts",
+  "src/worker.ts",
+  "src/residency/host.ts",
+  "src/residency/launcher.ts",
+  "src/residency/pi-entry.ts",
+  "src/residency/actor-client.ts",
+  "src/compaction/hook.ts",
+  "src/core/action-registry.ts",
+  "src/entropy/index.ts",
+  "src/memory/digest.ts",
+  "src/memory/search.ts",
+  "src/memory/discovery.ts",
+  "src/memory/normalize.ts",
+  "src/providers/memory-provider.ts",
+];
+
+// Every package-local dynamic import is also an entry point. Its stable output
+// path lets a session that loaded the previous index resolve delayed modules
+// after the installed package is replaced, while preserving lazy evaluation.
+const lazyEntryPoints = [
+  "src/agents/claude-cli.ts",
+  "src/agents/compact-control.ts",
+  "src/agents/veda-cli.ts",
+  "src/fabric-runtime-state.ts",
+  "src/runtime/core-override-guest-types.ts",
+  "src/runtime/dynamic-guest-types.ts",
+  "src/runtime/guest-types.ts",
+  "src/runtime/node-process-runtime.ts",
+  "src/runtime/quickjs-runtime.ts",
+  "src/runtime/type-checker.ts",
+  "src/speculation/scanner.ts",
+  "src/ui/dashboard.ts",
+  "src/ui/model-picker.ts",
+  "src/ui/settings.ts",
+  "src/worker/options.ts",
+  "src/worker/run-record.ts",
+  "src/worker/session-export.ts",
+];
+
 const result = await build({
-  entryPoints: [
-    "src/index.ts",
-    "src/protocol.ts",
-    "src/worker.ts",
-    "src/residency/host.ts",
-    "src/residency/launcher.ts",
-    "src/residency/pi-entry.ts",
-    "src/residency/actor-client.ts",
-    "src/compaction/hook.ts",
-    "src/core/action-registry.ts",
-    "src/entropy/index.ts",
-    "src/memory/digest.ts",
-    "src/memory/search.ts",
-    "src/memory/discovery.ts",
-    "src/memory/normalize.ts",
-    "src/providers/memory-provider.ts",
-  ],
+  entryPoints: [...primaryEntryPoints, ...lazyEntryPoints],
   outdir: "dist",
   outbase: "src",
   entryNames: "[dir]/[name]",
@@ -39,4 +64,21 @@ const bundledPackages = Object.keys(result.metafile.inputs).filter((input) =>
 );
 if (bundledPackages.length > 0) {
   throw new Error(`Package code was bundled unexpectedly:\n${bundledPackages.join("\n")}`);
+}
+
+const unstableLazyImports = Object.entries(result.metafile.outputs).flatMap(
+  ([output, metadata]) =>
+    metadata.imports
+      .filter(
+        (entry) =>
+          entry.kind === "dynamic-import" &&
+          !entry.external &&
+          entry.path.includes("/chunks/"),
+      )
+      .map((entry) => `${output} -> ${entry.path}`),
+);
+if (unstableLazyImports.length > 0) {
+  throw new Error(
+    `Package-local dynamic imports must use stable entry paths:\n${unstableLazyImports.join("\n")}`,
+  );
 }


### PR DESCRIPTION
## Summary

- emit every package-local dynamic import target as a stable entry path while retaining code splitting
- fail the build if a future local dynamic import falls back to a content-hashed chunk
- update artifact and managed-install assertions for the stable lazy runtime and UI entries

Closes #106

## Validation

- `bun run check` (177 files, 2,314 tests)
- simulated a live package replacement by loading an old entry, renaming all 42 hashed chunks in the replacement build, deleting the old build, and then loading the four delayed runtime/UI entries successfully
