### PR TITLE
fix(test): normalize Windows path fixtures

### DIFF
--- a/tests/agent-cwd.test.ts
+++ b/tests/agent-cwd.test.ts
@@ -38,7 +38,7 @@ const initRepository = (prefix: string, relativeDirectory?: string): string => {
   }
   git(repository, "add", ".");
   git(repository, "commit", "-qm", "initial");
-  return fs.realpathSync(repository);
+  return fs.realpathSync.native(repository);
 };
 
 const workerSource = `

--- a/tests/clone-first-worktree.test.ts
+++ b/tests/clone-first-worktree.test.ts
@@ -19,6 +19,7 @@ const initRepository = (): string => {
   git(repository, "init", "-q");
   git(repository, "config", "user.email", "pi-fabric-tests@example.invalid");
   git(repository, "config", "user.name", "Pi Fabric tests");
+  git(repository, "config", "core.autocrlf", "false");
   fs.writeFileSync(path.join(repository, "README.md"), "tracked head\n");
   fs.writeFileSync(path.join(repository, ".gitignore"), "node_modules/\n");
   fs.mkdirSync(path.join(repository, "node_modules", "pkg"), { recursive: true });
@@ -26,7 +27,7 @@ const initRepository = (): string => {
   git(repository, "add", ".");
   git(repository, "commit", "-qm", "initial");
   fs.writeFileSync(path.join(repository, "README.md"), "dirty working tree\n");
-  return fs.realpathSync(repository);
+  return fs.realpathSync.native(repository);
 };
 
 afterEach(() => {

--- a/tests/pi-tools-provider.test.ts
+++ b/tests/pi-tools-provider.test.ts
@@ -202,7 +202,9 @@ describe("PiToolsProvider lifecycle", () => {
   });
 
   it("preserves shell cwd through pi 0.85 argument preparation", async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fabric-provider-cwd-"));
+    const root = fs.realpathSync.native(
+      fs.mkdtempSync(path.join(os.tmpdir(), "pi-fabric-provider-cwd-")),
+    );
     const nested = path.join(root, "nested");
     fs.mkdirSync(nested);
     try {
@@ -210,7 +212,10 @@ describe("PiToolsProvider lifecycle", () => {
       registry.register(new PiToolsProvider(root, undefined, undefined));
       const result = await registry.invoke(
         "pi.bash",
-        { command: "pwd", cwd: "nested" },
+        {
+          command: `${JSON.stringify(process.execPath.replaceAll("\\", "/"))} -e "process.stdout.write(process.cwd())"`,
+          cwd: "nested",
+        },
         {
           ...baseContext,
           cwd: root,
@@ -218,7 +223,9 @@ describe("PiToolsProvider lifecycle", () => {
           audits: [],
         },
       ) as { output: string };
-      expect(result.output.trim()).toBe(fs.realpathSync(nested));
+      expect(fs.realpathSync.native(result.output.trim())).toBe(
+        fs.realpathSync.native(nested),
+      );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- canonicalize Git fixture roots with Node's native realpath implementation so Windows 8.3 and long paths compare consistently
- disable `core.autocrlf` in the clone-first fixture so its committed bytes are deterministic
- use a Node cwd probe instead of MSYS `pwd`, which reports `/tmp/...` for Windows temporary directories

This fixes the pre-existing Windows job failures on `main` that block #104 and #108 from becoming green.

## Validation

- `bunx vitest run tests/agent-cwd.test.ts tests/clone-first-worktree.test.ts tests/pi-tools-provider.test.ts` (30 tests)
- `bun run check` (177 files, 2,314 tests)
