### PR TITLE
fix(test): keep Windows Monty skill extraction and temp cleanup hermetic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Windows runners often inherit core.autocrlf=true; keep repository LF
+          # so markdown fence parsers and path fixtures stay hermetic.
+          core.autocrlf: false
       - uses: oven-sh/setup-bun@v2
       - name: Install ripgrep
         # pi's grep tool downloads rg on first use when it is absent; on shared

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4
-        with:
-          # Windows runners often inherit core.autocrlf=true; keep repository LF
-          # so markdown fence parsers and path fixtures stay hermetic.
-          core.autocrlf: false
       - uses: oven-sh/setup-bun@v2
       - name: Install ripgrep
         # pi's grep tool downloads rg on first use when it is absent; on shared

--- a/tests/fixtures/temp-cleanup.ts
+++ b/tests/fixtures/temp-cleanup.ts
@@ -9,8 +9,8 @@ export const rmTempSync = (root: string): void => {
       return;
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
-      if (attempt >= 5 || (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY")) throw error;
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+      if (attempt >= 12 || (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY")) throw error;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
     }
   }
 };

--- a/tests/python-skill-programs.test.ts
+++ b/tests/python-skill-programs.test.ts
@@ -36,7 +36,7 @@ const catalog: SkillHost = async (ref) => {
 };
 
 it("extracts python fences from CRLF checkouts", () => {
-  const lf = fs.readFileSync("skillsets/python/fabric-council/SKILL.md", "utf8");
+  const lf = fs.readFileSync("skillsets/python/fabric-council/SKILL.md", "utf8").replace(/\r\n?/g, "\n");
   expect(extractPythonPrograms(lf.replace(/\n/g, "\r\n"))).toEqual(extractPythonPrograms(lf));
   expect(extractPythonPrograms(lf).length).toBeGreaterThan(0);
 });

--- a/tests/python-skill-programs.test.ts
+++ b/tests/python-skill-programs.test.ts
@@ -11,9 +11,12 @@ const failed = { status: "failed", text: "", error: "worker unavailable" };
 const model = (id: string) => ({ provider: "test", id, name: id, key: `test/${id}` });
 const models = [model("one"), model("two"), model("three")];
 const fusionPayloads = { task: "inspect", panel: JSON.stringify([{ model: "test/one" }, { model: "test/two" }]), mode: "compare", thinking: "", judge: "", tools: "", actor: "test/three", actorTools: "" };
-const programs = (relative: string) => [...fs.readFileSync(`skillsets/python/${relative}`, "utf8").matchAll(/```python\n([\s\S]*?)\n```/g)].map((m) => m[1]!);
+const extractPythonPrograms = (source: string) => [...source.matchAll(/```python\r?\n([\s\S]*?)\r?\n```/g)].map((m) => m[1]!.replace(/\r\n?/g, "\n"));
+const programs = (relative: string) => extractPythonPrograms(fs.readFileSync(`skillsets/python/${relative}`, "utf8"));
 const execute = async (relative: string, payloads: Record<string, string>, host: SkillHost, index = 0) => {
-  const result = await new MontyRuntime().execute(programs(relative)[index]!, async (ref, args) => {
+  const extracted = programs(relative);
+  expect(extracted[index], relative).toBeDefined();
+  const result = await new MontyRuntime().execute(extracted[index]!, async (ref, args) => {
     if (ref.startsWith("agents.")) {
       const descriptor = AGENTS_ACTION_DESCRIPTORS.find((entry) => entry.name === ref.slice(7));
       expect(descriptor, ref).toBeDefined();
@@ -32,6 +35,12 @@ const catalog: SkillHost = async (ref) => {
   throw new Error(`Unexpected action ${ref}`);
 };
 
+it("extracts python fences from CRLF checkouts", () => {
+  const lf = fs.readFileSync("skillsets/python/fabric-council/SKILL.md", "utf8");
+  expect(extractPythonPrograms(lf.replace(/\n/g, "\r\n"))).toEqual(extractPythonPrograms(lf));
+  expect(extractPythonPrograms(lf).length).toBeGreaterThan(0);
+});
+
 describe.skipIf(!availablePythonBackends.monty)("Python-native skill behavior in Monty", () => {
   it("runs every execution reference and its Python-only branches", async () => {
     const host: SkillHost = async (ref, args) => {
@@ -45,6 +54,7 @@ describe.skipIf(!availablePythonBackends.monty)("Python-native skill behavior in
       return "example";
     };
     for (const file of ["fabric-exec/SKILL.md", "fabric-exec/references/agents.md", "fabric-exec/references/mesh.md", "fabric-exec/references/mcp.md"]) {
+      expect(programs(file).length, file).toBeGreaterThan(0);
       for (let index = 0; index < programs(file).length; index++) await execute(file, {}, host, index);
     }
   });

--- a/tests/worker-model-admission.test.ts
+++ b/tests/worker-model-admission.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentManager } from "../src/agents/manager.js";
 import { DEFAULT_FABRIC_CONFIG } from "../src/config.js";
+import { rmTempSync } from "./fixtures/temp-cleanup.js";
 
 const workerPath = path.resolve("dist/worker.js");
 const requested = "openai-codex/gpt-5.6-sol";
@@ -14,7 +15,7 @@ describe.skipIf(!fs.existsSync(workerPath))("real worker model admission", () =>
   afterEach(async () => {
     await Promise.all(managers.splice(0).map(manager => manager.close()));
     vi.unstubAllEnvs();
-    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+    for (const root of roots.splice(0)) rmTempSync(root);
   });
   const root = () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "fabric-model-admission-"));


### PR DESCRIPTION
## Summary
Windows `Test` has been red on `main` (ubuntu green, windows failing).

- `tests/python-skill-programs.test.ts`: Git for Windows `core.autocrlf=true` turned skill markdown into CRLF, so `/```python\n/` extracted no programs. Index 0 was `undefined`, Monty hit `code.replace`, and tests reported `runtime_error`. The empty first case still passed.
- `tests/worker-model-admission.test.ts`: afterEach `rmSync` hit `EBUSY` while a just-killed Pi worker still held the temp cwd.

## Changes
- Extract python fences with optional CR and normalize bodies to LF; fail if a fence is missing; cover CRLF checkouts.
- Use `rmTempSync` (longer EBUSY/EPERM retry) for worker admission temp dirs.
- Checkout with `core.autocrlf: false` so CI stays LF.

## Test plan
- [x] `bun run check` locally (typecheck, build, full tests, knip)
- [ ] Windows CI `check (windows-latest)` on this PR
