### PR TITLE
fix(runtime): project host undefined like JSON into Monty

### DIFF
--- a/src/runtime/monty-values.ts
+++ b/src/runtime/monty-values.ts
@@ -1,6 +1,8 @@
 const MAX_VALUE_BYTES = 16 * 1024 * 1024;
 
-/** Strict JSON boundary: never silently stringify bytes, sets, unsafe ints or cycles. */
+/** Strict JSON boundary: never silently stringify bytes, sets, unsafe ints or cycles.
+ * Host results follow JSON.stringify for `undefined`: omit object keys, null array holes.
+ */
 export function normalizeMontyValue(value: unknown, hostValue = false): unknown {
   let remaining = MAX_VALUE_BYTES;
   let nodes = 0;
@@ -12,6 +14,7 @@ export function normalizeMontyValue(value: unknown, hostValue = false): unknown 
     if (remaining < 0) throw new TypeError("Monty JSON value exceeds 16 MiB");
     if (item === null || typeof item === "string" || typeof item === "boolean") return item;
     if (typeof item === "number" && Number.isFinite(item) && (!Number.isInteger(item) || Number.isSafeInteger(item))) return item;
+    if (hostValue && item === undefined) return null;
     if (typeof item !== "object" || item === null) throw new TypeError("Monty boundary requires JSON-compatible values (finite numbers and safe integers)");
     if (active.has(item)) throw new TypeError("Monty boundary cannot serialize cyclic values");
     active.add(item);
@@ -24,6 +27,7 @@ export function normalizeMontyValue(value: unknown, hostValue = false): unknown 
       const result: Record<string, unknown> = {};
       for (const [key, entry] of item instanceof Map ? item.entries() : Object.entries(item)) {
         if (typeof key !== "string") throw new TypeError("Monty JSON dictionary keys must be strings");
+        if (hostValue && entry === undefined) continue;
         visit(key, depth + 1);
         Object.defineProperty(result, key, { value: visit(entry, depth + 1), enumerable: true, configurable: true, writable: true });
       }

--- a/tests/monty-runtime.test.ts
+++ b/tests/monty-runtime.test.ts
@@ -118,10 +118,21 @@ describe.skipIf(Boolean(missing))(`MontyRuntime native 0.0.23${missing ? " (" + 
 
   it("rejects non-JSON host returns without leaking capabilities", async () => {
     const cycle: Record<string, unknown> = {}; cycle.self = cycle;
-    for (const value of [1n, Infinity, Buffer.from("data"), new Set([1]), cycle, { fn: () => 1 }, { nested: undefined }]) {
+    for (const value of [1n, Infinity, Buffer.from("data"), new Set([1]), cycle, { fn: () => 1 }]) {
       expect((await run("return await schema.status()", async () => value)).terminationReason).toBe("runtime_error");
     }
     expect(await run("return await schema.status()", async () => undefined)).toMatchObject({ value: null, terminationReason: "completed" });
+    const optional = await run("return await schema.status()", async () => ({
+      text: "ok",
+      details: { scope: { path: undefined, language: undefined, kind: "function" }, seeds: 1 },
+      holes: [1, undefined, 3],
+    }));
+    expect(optional).toMatchObject({ terminationReason: "completed" });
+    expect(optional.value).toEqual({
+      text: "ok",
+      details: { scope: { kind: "function" }, seeds: 1 },
+      holes: [1, null, 3],
+    });
   });
 
   it("preserves dangerous-looking JSON dictionary keys without prototype or native-marker interpretation", async () => {


### PR DESCRIPTION
## Summary
Monty `fabric_exec` failed at `asyncio.gather` when `extensions.fovea_focus` returned optional `undefined` fields (`details.scope.path/language/kind`). Host conversion threw `TypeError: Monty boundary requires JSON-compatible values` even though the tool call succeeded.

CPython already projects this via `JSON.stringify`. Align Monty host results: omit undefined object keys, null array holes. Keep rejecting bytes, sets, cycles, functions, and unsafe numbers.

## Test plan
- [x] `bun run check`
- [x] monty-runtime host JSON projection coverage
