### PR TITLE
fix(runtime): validate timeout and log limits across kernels

### DIFF
--- a/src/runtime/node-process-runtime.ts
+++ b/src/runtime/node-process-runtime.ts
@@ -61,6 +61,14 @@ export class NodeProcessRuntime {
         error: "Process memory limit must be a positive safe integer",
       };
     }
+    if (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 1) {
+      return {
+        value: undefined,
+        logs: [],
+        terminationReason: "runtime_error",
+        error: "Process timeout must be positive",
+      };
+    }
 
     // Bun evaluates --eval input as ESM and ignores V8 heap flags, so the
     // Bun child gets the guest source bare; Node needs the module + heap flags.
@@ -122,11 +130,11 @@ export class NodeProcessRuntime {
         resolve(result);
       };
       const scheduleDeadline = (): void => {
-        if (deadline) clearTimeout(deadline);
+        clearTimeout(deadline);
         deadline = setTimeout(() => {
           const error = `Execution timed out after ${effectiveTimeoutMs}ms`;
           finish({ value: undefined, logs: [], terminationReason: "timed_out", error });
-        }, Math.max(0, deadlineAt - Date.now()));
+        }, Math.min(2_147_483_647, Math.max(0, deadlineAt - Date.now())));
         deadline.unref?.();
       };
       const extendDeadline = (ref: string, args: Record<string, unknown>): void => {

--- a/src/runtime/quickjs-runtime.ts
+++ b/src/runtime/quickjs-runtime.ts
@@ -824,6 +824,22 @@ export class QuickJsRuntime {
           + " For large or quote-heavy content, keep it in top-level payloads and reference π.<key> instead of escaping it inside code.",
       };
     }
+    if (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 1) {
+      return {
+        value: undefined,
+        logs: [],
+        terminationReason: "runtime_error",
+        error: "QuickJS timeout must be positive",
+      };
+    }
+    if (options.maxLogChars !== undefined && (!Number.isSafeInteger(options.maxLogChars) || options.maxLogChars < 0)) {
+      return {
+        value: undefined,
+        logs: [],
+        terminationReason: "runtime_error",
+        error: "QuickJS log limit must be a nonnegative safe integer",
+      };
+    }
     if (
       !Number.isSafeInteger(options.memoryLimitBytes) ||
       options.memoryLimitBytes < 1 ||
@@ -896,8 +912,8 @@ export class QuickJsRuntime {
     };
     const scheduleDeadline = (): void => {
       if (!rejectDeadline || closing || cancelled || timedOut) return;
-      if (timeout) clearTimeout(timeout);
-      timeout = setTimeout(expireDeadline, Math.max(0, executionDeadlineAt - Date.now()));
+      clearTimeout(timeout);
+      timeout = setTimeout(expireDeadline, Math.min(2_147_483_647, Math.max(0, executionDeadlineAt - Date.now())));
     };
     const extendExecutionTimeout = (
       ref: string,

--- a/tests/node-process-runtime.test.ts
+++ b/tests/node-process-runtime.test.ts
@@ -36,6 +36,17 @@ return { models, process: typeof process, require: typeof require };
       require: "undefined",
     });
   });
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 0, -100])("rejects non-positive timeout %s without spawning", async (timeoutMs) => {
+    const result = await new NodeProcessRuntime().execute(
+      "return 1;",
+      async () => undefined,
+      { ...options, timeoutMs },
+    );
+
+    expect(result.terminationReason).toBe("runtime_error");
+    expect(result.error).toBe("Process timeout must be positive");
+  });
+
 
   it("normalizes the string shorthand for tools.search", async () => {
     const result = await new NodeProcessRuntime().execute(

--- a/tests/quickjs-runtime.test.ts
+++ b/tests/quickjs-runtime.test.ts
@@ -19,6 +19,28 @@ describe("QuickJsRuntime", () => {
     expect(result.terminationReason).toBe("runtime_error");
     expect(result.error).toContain("WASM32 maximum");
   });
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 0, -5])("rejects non-positive timeout %s like the Python kernels", async (timeoutMs) => {
+    const result = await new QuickJsRuntime().execute(
+      "return 1;",
+      async () => undefined,
+      { ...options, timeoutMs },
+    );
+
+    expect(result.terminationReason).toBe("runtime_error");
+    expect(result.error).toBe("QuickJS timeout must be positive");
+  });
+
+  it("rejects negative log limits like the Monty kernel", async () => {
+    const result = await new QuickJsRuntime().execute(
+      "return 1;",
+      async () => undefined,
+      { ...options, maxLogChars: -10 },
+    );
+
+    expect(result.terminationReason).toBe("runtime_error");
+    expect(result.error).toBe("QuickJS log limit must be a nonnegative safe integer");
+  });
+
 
   it("runs parallel host calls and returns structured data", async () => {
     const hostCall = vi.fn(async (ref: string, args: Record<string, unknown>) => ({


### PR DESCRIPTION
Fixes #135.

## What

`QuickJsRuntime` and `NodeProcessRuntime` never validated `timeoutMs` (QuickJS also ignored `maxLogChars`), while Monty/CPython fail closed. Invalid deadlines flowed into the watchdogs:

- `NaN` → bogus `timed_out` ("Execution timed out after NaNms") instead of `runtime_error`
- `Infinity` → `setTimeout` overflow fires in ~1ms ("after Infinityms")
- `0` / negative → instant premature timeout, after spawning a child on node-process

All four kernels now reject non-finite or `< 1` `timeoutMs` with `runtime_error` before allocating any runtime/child process, QuickJS validates `maxLogChars` like Monty, and watchdog timers are clamped to `2_147_483_647`ms:

```mermaid
flowchart LR
    A["execute(timeoutMs)"] --> B{finite && >= 1?}
    B -->|no| C["runtime_error before any spawn"]
    B -->|yes| D["run with deadline"]
    D --> E["watchdog clamped to 2^31-1 ms"]
    subgraph kernels["all kernels: quickjs / node-process / monty / cpython"]
    B
    end
```

## Verification

- 9 new regression cases (`tests/quickjs-runtime.test.ts`, `tests/node-process-runtime.test.ts`): fail on `main` (9 failed / 74 passed), pass with this fix.
- `tsc --noEmit`, bundle build + artifact/lazy-graph asserts, `knip` clean.
- Full suite: only 2 failures, both pre-existing on clean `main` and environmental (missing `bun` binary, no CPython sandbox here).
