### PR TITLE
fix(output): never truncate the full-output artifact path

### DIFF
--- a/src/output-budget.ts
+++ b/src/output-budget.ts
@@ -48,9 +48,23 @@ export const boundModelOutput = async (
     ? `\n\n[Full output (${fullOutput.length} chars) saved to: ${artifactPath}]`
     : "";
   const bodyBudget = Math.max(1, maxChars - suffix.length);
-  const text = `${truncateMiddle(visible, bodyBudget)}${suffix}`;
+  const body = truncateMiddle(visible, bodyBudget);
+  let text = `${body}${suffix}`;
+  if (text.length > maxChars) {
+    // The suffix carries the artifact path; shrink the body again instead of
+    // cutting into the path. A truncation marker can itself exceed a tiny
+    // rebudget, so fall back to the bare suffix (or its tail), which always
+    // fits and still ends with the path.
+    const rebudget = maxChars - suffix.length;
+    if (rebudget <= 0) {
+      text = suffix.slice(-Math.max(1, maxChars));
+    } else {
+      const shrunk = truncateMiddle(body, rebudget);
+      text = shrunk.length + suffix.length <= maxChars ? `${shrunk}${suffix}` : suffix;
+    }
+  }
   return {
-    text: text.length <= maxChars ? text : truncateMiddle(text, maxChars),
+    text,
     ...(artifactPath ? { artifactPath } : {}),
     originalChars: fullOutput.length,
     omittedChars: Math.max(0, fullOutput.length - Math.min(fullOutput.length, bodyBudget)),

--- a/tests/output-budget.test.ts
+++ b/tests/output-budget.test.ts
@@ -39,6 +39,18 @@ describe("boundModelOutput", () => {
     expect(result.omittedChars).toBeGreaterThan(0);
     expect(writer).toHaveBeenCalledWith(full);
   });
+  it("never cuts the artifact path when the budget barely fits the suffix", async () => {
+    const full = "x".repeat(4_000);
+    const artifactPath = "/tmp/pi-fabric-output/output.txt";
+    const writer = vi.fn(async () => artifactPath);
+    const result = await boundModelOutput(full, 100, full, writer);
+
+    expect(result.text.length).toBeLessThanOrEqual(100);
+    expect(result.text).toContain(artifactPath);
+    expect(result.artifactPath).toBe(artifactPath);
+    expect(result.omittedChars).toBeGreaterThan(0);
+  });
+
 
   it("persists retrievable artifacts with private POSIX permissions", async () => {
     const result = await boundModelOutput("x".repeat(4_000), 1_000);


### PR DESCRIPTION
Fixes #137.

## What

`boundModelOutput` links the spilled full output via a suffix (`[Full output (N chars) saved to: PATH]`), but the final bounding step truncated the whole text *including* that suffix — tight budgets destroyed the path they just linked. Now the second pass shrinks only the body; if even a truncation marker can't fit, it falls back to the bare suffix (or its tail), which still ends with the path. `omittedChars` semantics unchanged.

```mermaid
flowchart TD
    A["body + suffix(path) > maxChars?"] -->|no| B["return as-is"]
    A -->|yes| C["rebudget = maxChars - suffix.length"]
    C --> D{rebudget > 0?}
    D -->|yes| E["truncate body again; if marker still overflows, return bare suffix"]
    D -->|no| F["return tail of suffix — still ends with path"]
```

## Verification

- New case (`tests/output-budget.test.ts`, budget 100 vs 4000-char output): fails on `main` (path middle-truncated away), passes here; text stays ≤ budget and always contains `artifactPath`.
- `tsc --noEmit` clean; full `output-budget` suite (6 tests) green.
