### PR TITLE
fix(residency): clean up abandoned file-exchange requests

### DIFF
--- a/src/residency/actor-client.ts
+++ b/src/residency/actor-client.ts
@@ -4,17 +4,16 @@ import path from "node:path";
 import { writeJsonAtomic } from "../core/atomic-write.js";
 import type { FabricActorInfo, FabricActorRequest } from "../actors/types.js";
 import {
+  abandonResidentRequest,
   RESIDENT_HOST_FORMAT,
   residentRoot,
+  sleepUnlessAborted,
   type ResidentCommand,
   type ResidentCommandResponse,
 } from "./protocol.js";
 
 const COMMAND_TIMEOUT_MS = 30_000;
 const STATUS_POLL_MS = 100;
-
-const delay = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
 
 const readJson = <T>(filePath: string): T | undefined => {
   try {
@@ -50,7 +49,7 @@ export class ResidentActorClient {
     return new ResidentActorClient(meshRoot, rootId);
   }
 
-  async createActor(request: FabricActorRequest): Promise<FabricActorInfo> {
+  async createActor(request: FabricActorRequest, signal?: AbortSignal): Promise<FabricActorInfo> {
     const response = await this.#send({
       format: RESIDENT_HOST_FORMAT,
       operation: "createActor",
@@ -58,12 +57,12 @@ export class ResidentActorClient {
       rootId: this.#rootId,
       request,
       createdAt: Date.now(),
-    });
+    }, signal);
     if (!response.actor) throw new Error("Resident host returned no actor from createActor");
     return response.actor;
   }
 
-  async removeActor(id: string): Promise<{ removed: true }> {
+  async removeActor(id: string, signal?: AbortSignal): Promise<{ removed: true }> {
     await this.#send({
       format: RESIDENT_HOST_FORMAT,
       operation: "removeActor",
@@ -71,26 +70,32 @@ export class ResidentActorClient {
       rootId: this.#rootId,
       id,
       createdAt: Date.now(),
-    });
+    }, signal);
     return { removed: true };
   }
 
-  async #send(command: ResidentCommand): Promise<ResidentCommandResponse> {
+  async #send(command: ResidentCommand, signal?: AbortSignal): Promise<ResidentCommandResponse> {
     fs.mkdirSync(this.#requestsPath, { recursive: true });
     writeJsonAtomic(path.join(this.#requestsPath, `${command.requestId}.json`), command);
     const responsePath = path.join(this.#responsesPath, `${command.requestId}.json`);
     const deadline = Date.now() + COMMAND_TIMEOUT_MS;
-    while (Date.now() < deadline) {
-      const response = readJson<ResidentCommandResponse>(responsePath);
-      if (response?.format === RESIDENT_HOST_FORMAT && response.requestId === command.requestId) {
-        fs.rmSync(responsePath, { force: true });
-        if (!response.ok) throw new Error(response.error ?? "Resident host rejected actor request");
-        return response;
+    try {
+      while (Date.now() < deadline) {
+        if (signal?.aborted) throw new Error("Resident host actor request was aborted");
+        const response = readJson<ResidentCommandResponse>(responsePath);
+        if (response?.format === RESIDENT_HOST_FORMAT && response.requestId === command.requestId) {
+          fs.rmSync(responsePath, { force: true });
+          if (!response.ok) throw new Error(response.error ?? "Resident host rejected actor request");
+          return response;
+        }
+        const owner = readJson<{ pid?: number }>(this.#ownerPath);
+        if (!owner?.pid) throw new Error("Root resident host exited during actor request");
+        await sleepUnlessAborted(STATUS_POLL_MS, signal).catch(() => undefined);
       }
-      const owner = readJson<{ pid?: number }>(this.#ownerPath);
-      if (!owner?.pid) throw new Error("Root resident host exited during actor request");
-      await delay(STATUS_POLL_MS);
+      throw new Error("Timed out waiting for resident host actor response");
+    } catch (error) {
+      abandonResidentRequest(this.#requestsPath, this.#responsesPath, command.requestId);
+      throw error;
     }
-    throw new Error("Timed out waiting for resident host actor response");
   }
 }

--- a/src/residency/client.ts
+++ b/src/residency/client.ts
@@ -15,9 +15,11 @@ import type { FabricMainAgentTarget } from "../main-agent.js";
 import { MeshStore, type MeshStateEntry } from "../mesh/store.js";
 import type { FabricParticipantSource } from "../topology/types.js";
 import {
+  abandonResidentRequest,
   RESIDENT_HOST_FORMAT,
   residentDeliveryPrefix,
   residentHostId,
+  sleepUnlessAborted,
   type ResidentAgentMetadata,
   type ResidentCommand,
   type ResidentCommandResponse,
@@ -302,7 +304,7 @@ export class ResidencyClient {
       if (signal?.aborted) throw new Error(`Waiting for durable Fabric agent ${id} was aborted`);
       const status = this.statusAgent(id);
       if (terminal(status.status) && "startedAt" in status) return status as AgentRunResult;
-      await delay(STATUS_POLL_MS);
+      await sleepUnlessAborted(STATUS_POLL_MS, signal).catch(() => undefined);
     }
   }
 
@@ -396,19 +398,24 @@ export class ResidencyClient {
     const responsePath = path.join(this.#responsesPath, `${command.requestId}.json`);
     atomicWrite(path.join(this.#requestsPath, `${command.requestId}.json`), command);
     const deadline = Date.now() + COMMAND_TIMEOUT_MS;
-    while (Date.now() < deadline) {
-      if (signal?.aborted) throw new Error("Fabric residency request was aborted");
-      const response = readJson<ResidentCommandResponse>(responsePath);
-      if (response?.format === RESIDENT_HOST_FORMAT && response.requestId === command.requestId) {
-        fs.rmSync(responsePath, { force: true });
-        if (!response.ok) throw new Error(response.error ?? "Fabric resident host rejected request");
-        return response;
+    try {
+      while (Date.now() < deadline) {
+        if (signal?.aborted) throw new Error("Fabric residency request was aborted");
+        const response = readJson<ResidentCommandResponse>(responsePath);
+        if (response?.format === RESIDENT_HOST_FORMAT && response.requestId === command.requestId) {
+          fs.rmSync(responsePath, { force: true });
+          if (!response.ok) throw new Error(response.error ?? "Fabric resident host rejected request");
+          return response;
+        }
+        const owner = this.#liveOwner();
+        if (!owner) throw new Error("Fabric resident host exited while processing a request");
+        await sleepUnlessAborted(STATUS_POLL_MS, signal).catch(() => undefined);
       }
-      const owner = this.#liveOwner();
-      if (!owner) throw new Error("Fabric resident host exited while processing a request");
-      await delay(STATUS_POLL_MS);
+      throw new Error(`Timed out waiting for Fabric residency request ${command.requestId}`);
+    } catch (error) {
+      abandonResidentRequest(this.#requestsPath, this.#responsesPath, command.requestId);
+      throw error;
     }
-    throw new Error(`Timed out waiting for Fabric residency request ${command.requestId}`);
   }
 
   async #waitForParticipant(id: string, kind: "actor" | "agent"): Promise<void> {

--- a/src/residency/protocol.ts
+++ b/src/residency/protocol.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import fs from "node:fs";
 import path from "node:path";
 import type { FabricOwnedModelGuidance } from "../components/model-guidance.js";
 import type { FabricModelCandidate } from "../core/model-resolution.js";
@@ -7,6 +8,47 @@ import type { FabricActorInfo, FabricActorRequest } from "../actors/types.js";
 import type { AgentHandleInfo, AgentRunRequest } from "../agents/types.js";
 import type { FabricKernel } from "../runtime/kernel.js";
 import type { MeshIdentity } from "../mesh/store.js";
+export const sleepUnlessAborted = (ms: number, signal?: AbortSignal): Promise<void> =>
+  // Executor form: the configured lib is ES2022, which has no
+  // Promise.withResolvers, and an abort listener plus a timer need shared
+  // completion control.
+  new Promise<void>((resolve, reject) => {
+    const aborted = (): Error =>
+      signal?.reason instanceof Error ? signal.reason : new Error("Fabric residency request was aborted");
+    if (signal?.aborted) {
+      reject(aborted());
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, Math.max(0, ms));
+    timer.unref?.();
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(aborted());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+
+/**
+ * Remove an abandoned file-exchange request. The resident host renames
+ * unstarted requests out of `requests/` before running them, so deleting our
+ * file cancels work the host has not picked up yet; a late host response is
+ * removed as well. Deleting a request the host already moved is a no-op, and
+ * in-flight work still runs to completion. Best effort: never throws.
+ */
+export const abandonResidentRequest = (
+  requestsPath: string,
+  responsesPath: string,
+  requestId: string,
+): void => {
+  for (const directory of [requestsPath, responsesPath]) {
+    try {
+      fs.rmSync(path.join(directory, `${requestId}.json`), { force: true });
+    } catch { /* best effort: an abandoned request must not raise a second error */ }
+  }
+};
 
 export const RESIDENT_HOST_FORMAT = 1 as const;
 const RESIDENT_DELIVERY_PREFIX = "residency/deliveries/";

--- a/tests/residency-request-lifecycle.test.ts
+++ b/tests/residency-request-lifecycle.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  abandonResidentRequest,
+  sleepUnlessAborted,
+} from "../src/residency/protocol.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("abandonResidentRequest", () => {
+  it("removes the abandoned request and its late response, leaving siblings alone", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fabric-abandon-"));
+    const requests = path.join(root, "requests");
+    const responses = path.join(root, "responses");
+    fs.mkdirSync(requests, { recursive: true });
+    fs.mkdirSync(responses, { recursive: true });
+    fs.writeFileSync(path.join(requests, "gone.json"), "{}");
+    fs.writeFileSync(path.join(responses, "gone.json"), "{}");
+    fs.writeFileSync(path.join(requests, "kept.json"), "{}");
+
+    try {
+      abandonResidentRequest(requests, responses, "gone");
+      expect(fs.existsSync(path.join(requests, "gone.json"))).toBe(false);
+      expect(fs.existsSync(path.join(responses, "gone.json"))).toBe(false);
+      expect(fs.existsSync(path.join(requests, "kept.json"))).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("never throws for missing files or directories", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fabric-abandon-"));
+    try {
+      expect(() =>
+        abandonResidentRequest(path.join(root, "no-requests"), path.join(root, "no-responses"), "absent"),
+      ).not.toThrow();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("sleepUnlessAborted", () => {
+  it("resolves after the interval without a signal", async () => {
+    vi.useFakeTimers();
+    const pending = sleepUnlessAborted(100);
+    vi.advanceTimersByTime(100);
+    await pending;
+  });
+
+  it("rejects immediately for an already-aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("stop"));
+    await expect(sleepUnlessAborted(1_000, controller.signal)).rejects.toThrow("stop");
+  });
+
+  it("wakes without waiting out the interval when aborted mid-sleep", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const pending = sleepUnlessAborted(30_000, controller.signal);
+    controller.abort(new Error("mid-sleep stop"));
+    await expect(pending).rejects.toThrow("mid-sleep stop");
+  });
+});


### PR DESCRIPTION
Fixes #139.

## What

File-exchange requests (`requests/<id>.json`) left behind when a residency call timed out, aborted, or found the host gone could be picked up late by the resident host — running abandoned work — while dead files accumulated. Now:

- `abandonResidentRequest(requestsPath, responsesPath, requestId)` (new in `src/residency/protocol.ts`, best-effort, never throws) runs on every failure path of `ResidencyClient.#command` and `ResidentActorClient.#send`. Deleting pre-pickup genuinely cancels unstarted work (the host renames into `processing/` before running); post-move deletes are no-ops and in-flight work completes.
- `createActor`/`removeActor` take an optional `AbortSignal`; `waitAgent` and both poll loops sleep via shared `sleepUnlessAborted`, which rejects on abort instead of sleeping through it.

```mermaid
flowchart TD
    A["#command / #send failure"] --> B["abandonResidentRequest"]
    B --> C["rm requests/<id>.json → cancels unstarted work"]
    B --> D["rm responses/<id>.json → no orphan replies"]
    E["signal aborts mid-poll"] --> F["sleepUnlessAborted rejects → loop exits promptly"]
```

## Verification

- New `tests/residency-request-lifecycle.test.ts` (5 cases, fake timers — no wall-clock flakiness): fail on `main`, pass here.
- Existing `residency` + `residency-launcher` suites unaffected; `tsc --noEmit` clean.
