### PR TITLE
fix(config): floor fractional integers instead of resetting to defaults

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -550,8 +550,8 @@ const booleanValue = (value: unknown, fallback: boolean): boolean =>
   typeof value === "boolean" ? value : fallback;
 
 const boundedInteger = (value: unknown, fallback: number, min: number, max: number): number =>
-  typeof value === "number" && Number.isInteger(value)
-    ? Math.max(min, Math.min(max, value))
+  typeof value === "number" && Number.isFinite(value)
+    ? Math.max(min, Math.min(max, Math.floor(value)))
     : fallback;
 
 const boundedFloat = (value: unknown, fallback: number, min: number, max: number): number =>

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -152,6 +152,14 @@ describe("Fabric configuration", () => {
     });
     expect(floored.executor.hostCallTimeouts).toEqual({ "extensions.subagent": 300_000 });
   });
+  it("floors fractional integers instead of resetting them to defaults", () => {
+    const normalized = normalizeFabricConfig({
+      executor: { timeoutMs: 1500.9, maxOutputChars: 2500.5 },
+    });
+    expect(normalized.executor.timeoutMs).toBe(1500);
+    expect(normalized.executor.maxOutputChars).toBe(2500);
+  });
+
 
   it("normalizes executor runtimes and their memory ceilings", () => {
     const native = normalizeFabricConfig({


### PR DESCRIPTION
Fixes #141.

## What

One-line change in `boundedInteger` (`src/config.ts`): floor finite numbers before clamping instead of requiring `Number.isInteger` and resetting fractionals to the default. Covers all ~50 numeric settings at once. `NaN`/`Infinity`/non-numbers still fall back.

```mermaid
flowchart LR
    A["1500.9"] --> B["floor → 1500 → clamp → 1500"]
    C["NaN / 'x' / missing"] --> D["default (unchanged)"]
```

## Verification

- New case in `tests/config.test.ts` (`timeoutMs: 1500.9 → 1500`, `maxOutputChars: 2500.5 → 2500`): fails on `main`, passes here.
- Full `config` suite (48 tests) green; `tsc --noEmit` clean.
